### PR TITLE
export module as system-independent flake output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,14 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      {
+    let
+      exports = {
         nixosModules.age = import ./modules/age.nix;
-        packages = nixpkgs.legacyPackages.${system}.callPackage ./default.nix {};
+      };
+      outputs = flake-utils.lib.eachDefaultSystem (system: {
+        packages = nixpkgs.legacyPackages.${system}.callPackage ./default.nix { };
         defaultPackage = self.packages.${system}.agenix;
       });
+    in
+    exports // outputs;
 }


### PR DESCRIPTION
The example in the README uses `agenix.nixosModules.age` as the NixOS module, but that causes an "attribute 'age' missing" error for me. I've had to use `agenix.nixosModules.x86_64-linux.age` instead. `nix flake show` sees no module in there either:

```
nix flake show 'github:ryantm/agenix'
github:ryantm/agenix/8af97149b28adaf28699af923c35633310d52edf
[…]
├───nixosModules
│   ├───aarch64-linux: NixOS module
│   ├───i686-linux: NixOS module
│   ├───x86_64-darwin: NixOS module
│   └───x86_64-linux: NixOS module
[…]
```
This is because flake-utils doesn't try to distinguish outputs with `${system}` keys from those without.

In my own flakes I've been using a pattern inspired by [this idea for system-dependent and system-independent outputs](https://github.com/NixOS/nix/issues/3843#issuecomment-661720562), and it's the same pattern I'm using in this PR.

Because someone may already be using the current paths, I've kept `nixosModules` as is, and added a singular `nixosModule` output, which isn't recognized by `nix flake show` but is [documented in the wiki](https://nixos.wiki/wiki/Flakes#Output_schema). Alternatively I can change `nixosModules` to match the documentation,

I'm marking this as WIP because the README needs to be updated based on the previous paragraph.
