### PR TITLE
correctly list non-root secrets

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -23,7 +23,7 @@ let
   rootOwnedSecrets = builtins.filter (st: st.owner == "root" && st.group == "root") (builtins.attrValues cfg.secrets);
   installRootOwnedSecrets = builtins.concatStringsSep "\n" (["echo '[agenix] decrypting root secrets...'"] ++ (map installSecret rootOwnedSecrets));
 
-  nonRootSecrets = builtins.filter (st: st.owner != "root" && st.group != "root") (builtins.attrValues cfg.secrets);
+  nonRootSecrets = builtins.filter (st: st.owner != "root" || st.group != "root") (builtins.attrValues cfg.secrets);
   installNonRootSecrets = builtins.concatStringsSep "\n" (["echo '[agenix] decrypting non-root secrets...'"] ++ (map installSecret nonRootSecrets));
 
   secretType = types.submodule ({ config, ... }: {


### PR DESCRIPTION
The `rootOwnedSecrets`/`nonRootSecrets` logic excluded secrets that are only partly owned by root (i.e. as either user or group, not both). These now run under the latter during activation.