### PR TITLE
Need Foundation to build i18n-embed-fl on darwin

### DIFF
--- a/pkgs/rage.nix
+++ b/pkgs/rage.nix
@@ -15,7 +15,10 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.Security ];
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ 
+    darwin.Security
+    darwin.apple_sdk.frameworks.Foundation
+  ];
 
   postBuild = ''
     cargo run --example generate-docs


### PR DESCRIPTION
I got a compile error while building the project on macOS 10.15.7.

The error message said something about Foundation missing so I added ` darwin.apple_sdk.frameworks.Foundation` and now the build succeeds. 