### PR TITLE
modules/age: symlink files into place

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ but, if you want to (change the system based on your system):
    ```
 6. NixOS rebuild or use your deployment tool like usual.
 
-   The secret will be decrypted to the value of `age.secrets.secret1.path` (`/run/secrets/secret1` by default). For per-secret options controlling ownership etc, see [modules/age.nix](modules/age.nix).
+   The secret will be decrypted to the value of `age.secrets.secret1.path` (`/run/agenix/secret1` by default). For per-secret options controlling ownership etc, see [modules/age.nix](modules/age.nix).
 
 ## Rekeying
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,22 @@ randomness in `age`'s encryption algorithms, the files always change
 when rekeyed, even if the identities do not. (This eventually could be
 improved upon by reading the identities from the age file.)
 
+## Don't symlink secret
+
+If your secret cannot be a symlink, you should set the `symlink` option to `false`:
+
+```nix
+{
+  age.secrets.some-secret = {
+    file = ./secret;
+    path = "/var/lib/some-service/some-secret";
+    symlink = false;
+  };
+}
+```
+
+Instead of first decrypting the secret to `/run/agenix` and then symlinking to its `path`, the secret will instead be forcibly moved to its `path`. Please note that, currently, there are no cleanup mechanisms for secrets that are not symlinked by agenix.
+
 ## Threat model/Warnings
 
 This project has not be audited by a security professional.

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -138,6 +138,11 @@ in
       chmod 0750 "${cfg.secretsMountPoint}/$_count"
       chown :keys "${cfg.secretsMountPoint}" "${cfg.secretsMountPoint}/$_count"
       ln -sfn "${cfg.secretsMountPoint}/$_count" /run/secrets
+
+      (( _agenix_generation > 1 )) && {
+        echo "[agenix] removing old secrets (generation $(( _agenix_generation - 1 )))..."
+        rm -rf "${cfg.secretsMountPoint}/$(( _agenix_generation - 1 ))"
+      }
     '';
 
     # Secrets with root owner and group can be installed before users

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -28,7 +28,7 @@ let
     chmod ${secretType.mode} "$TMP_FILE"
     chown ${secretType.owner}:${secretType.group} "$TMP_FILE"
     mv -f "$TMP_FILE" "$_truePath"
-    [ "${secretType.path}" != "/run/secrets/${secretType.name}" ] && ln -sfn "/run/secrets/${secretType.name}" "${secretType.path}"
+    [ "${secretType.path}" != "/run/agenix/${secretType.name}" ] && ln -sfn "/run/agenix/${secretType.name}" "${secretType.path}"
   '';
 
   isRootSecret = st: (st.owner == "root" || st.owner == "0") && (st.group == "root" || st.group == "0");
@@ -46,7 +46,7 @@ let
         type = types.str;
         default = config._module.args.name;
         description = ''
-          Name of the file used in /run/secrets
+          Name of the file used in /run/agenix
         '';
       };
       file = mkOption {
@@ -57,7 +57,7 @@ let
       };
       path = mkOption {
         type = types.str;
-        default = "/run/secrets/${config.name}";
+        default = "/run/agenix/${config.name}";
         description = ''
           Path where the decrypted secret is installed.
         '';
@@ -101,9 +101,9 @@ in
           (builtins.match "[ \t\n]*" s) == null # non-empty
             && (builtins.match ".+/" s) == null) # without trailing slash
       // { description = "${types.str.description} (with check: non-empty without trailing slash)"; };
-      default = "/run/secrets.d";
+      default = "/run/agenix.d";
       description = ''
-        Where secrets are created before they are symlinked to /run/secrets
+        Where secrets are created before they are symlinked to /run/agenix
       '';
     };
     sshKeyPaths = mkOption {
@@ -128,16 +128,15 @@ in
     # ensure removed secrets are actually removed, or at least become
     # invalid symlinks).
     system.activationScripts.agenixMountSecrets = ''
-      _count="$(basename "$(readlink /run/secrets)" || echo 0)"
-      (( ++_count ))
-      echo "[agenix] symlinking new secrets to /run/secrets (generation $_count)..."
+      _agenix_generation="$(basename "$(readlink /run/agenix)" || echo 0)"
+      (( ++_agenix_generation ))
+      echo "[agenix] symlinking new secrets to /run/agenix (generation $_agenix_generation)..."
       mkdir -p "${cfg.secretsMountPoint}"
       chmod 0750 "${cfg.secretsMountPoint}"
       grep -q "${cfg.secretsMountPoint} ramfs" /proc/mounts || mount -t ramfs none "${cfg.secretsMountPoint}" -o nodev,nosuid,mode=0750
-      mkdir -p "${cfg.secretsMountPoint}/$_count"
-      chmod 0750 "${cfg.secretsMountPoint}/$_count"
-      chown :keys "${cfg.secretsMountPoint}" "${cfg.secretsMountPoint}/$_count"
-      ln -sfn "${cfg.secretsMountPoint}/$_count" /run/secrets
+      mkdir -p "${cfg.secretsMountPoint}/$_agenix_generation"
+      chmod 0750 "${cfg.secretsMountPoint}/$_agenix_generation"
+      ln -sfn "${cfg.secretsMountPoint}/$_agenix_generation" /run/agenix
 
       (( _agenix_generation > 1 )) && {
         echo "[agenix] removing old secrets (generation $(( _agenix_generation - 1 )))..."


### PR DESCRIPTION
This follows sops-nix's implementation, where it creates a
`/run/secrets.d` ramfs mountpoint and a "generation" each time
the activation script runs, and then symlinks `/run/secrets` to
`/run/secrets.d/[generation]`.

---

Fixes #26.
Fixes #21.

---

~~TODO (maybe): is it possible to not create a new generation each time activation runs (if nothing changed)? Does sops-nix do this?~~ While possible, this would introduce a decent amount of complexity for (IMHO) no gain. Since we remove old secrets generations, I think this is unnecessary.