### PR TITLE
modules/age: set LANG

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -14,7 +14,7 @@ let
     echo "decrypting ${secretType.file} to ${secretType.path}..."
     TMP_FILE="${secretType.path}.tmp"
     mkdir -p $(dirname ${secretType.path})
-    (umask 0400; ${ageBin} --decrypt ${identities} -o "$TMP_FILE" "${secretType.file}")
+    (umask 0400; LANG=${config.i18n.defaultLocale} ${ageBin} --decrypt ${identities} -o "$TMP_FILE" "${secretType.file}")
     chmod ${secretType.mode} "$TMP_FILE"
     chown ${secretType.owner}:${secretType.group} "$TMP_FILE"
     mv -f "$TMP_FILE" '${secretType.path}'


### PR DESCRIPTION
rage has a localization crate as a dependency that whines when LANG
is unset.

---

This fixes the slightly annoying (but cosmetic) issue where

```
[ERROR i18n_embed::requester] Unable to parse your locale: ParserError(InvalidLanguage)
```

is spammed to the stage-2 console while decrypting secrets.