### PR TITLE
Fix relative path to `rage.nix`

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -8,7 +8,7 @@ let
   # we need at least rage 0.5.0 to support ssh keys
   rage =
     if lib.versionOlder pkgs.rage.version "0.5.0"
-    then pkgs.callPackage ./rage.nix { }
+    then pkgs.callPackage ../pkgs/rage.nix { }
     else pkgs.rage;
   ageBin = "${rage}/bin/rage";
 


### PR DESCRIPTION
Seems like some refactoring caused this path to be wrong? 