### PR TITLE
add .nix extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ nix-channel --update
 
 ```nix
 {
-  imports = [ <agenix/modules/age> ];
+  imports = [ <agenix/modules/age.nix> ];
 }
 ```
 
@@ -67,7 +67,7 @@ $ nix-channel --update
 
 ```nix
 {
-  imports = [ "${builtins.fetchTarball "https://github.com/ryantm/agenix/archive/master.tar.gz"}/modules/age" ];
+  imports = [ "${builtins.fetchTarball "https://github.com/ryantm/agenix/archive/master.tar.gz"}/modules/age.nix" ];
 }
 ```
 


### PR DESCRIPTION
on my system (21.05.1759.91903ceb294 (Okapi)) I needed to add the .nix extensions on age to get nixos-rebuild to find the module. This seems to be inline with the modules directory structure:
`modules/age/nix`
rather than
`modules/age/default.nix`
but I'm not an expert on nix's file naming conventions.

I did not test the other ways of installing agenix  but am happy to run through them if this is a desired change.