### PR TITLE
fix: workaround for #54

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, options, lib, pkgs, ... }:
 
 with lib;
 
@@ -103,18 +103,29 @@ in
       '';
     };
   };
-  config = mkIf (cfg.secrets != { }) {
-    assertions = [{
-      assertion = cfg.sshKeyPaths != [ ];
-      message = "age.sshKeyPaths must be set.";
-    }];
+  config = mkIf (cfg.secrets != { }) (mkMerge [
 
-    # Secrets with root owner and group can be installed before users
-    # exist. This allows user password files to be encrypted.
-    system.activationScripts.agenixRoot = stringAfter [ "specialfs" ] installRootOwnedSecrets;
-    system.activationScripts.users.deps = [ "agenixRoot" ];
+    {
+      assertions = [{
+        assertion = cfg.sshKeyPaths != [ ];
+        message = "age.sshKeyPaths must be set.";
+      }];
 
-    # Other secrets need to wait for users and groups to exist.
-    system.activationScripts.agenix = stringAfter [ "users" "groups" "specialfs" ] installNonRootSecrets;
-  };
+      # Secrets with root owner and group can be installed before users
+      # exist. This allows user password files to be encrypted.
+      system.activationScripts.agenixRoot = stringAfter [ "specialfs" ] installRootOwnedSecrets;
+      system.activationScripts.users.deps = [ "agenixRoot" ];
+
+      # Other secrets need to wait for users and groups to exist.
+      system.activationScripts.agenix = stringAfter [ "users" "groups" "specialfs" ] installNonRootSecrets;
+
+    }
+
+    # workaround for #54
+    (optionalAttrs (builtins.hasAttr "dryActivationScript" options.system) {
+      system.activationScripts.users.supportsDryActivation = mkForce false;
+      system.activationScripts.groups.supportsDryActivation = mkForce false;
+    })
+
+  ]);
 }


### PR DESCRIPTION
This is meant to be a temporary workaround while we add support for dry activation scripts in #56 .