### PR TITLE
home-manager: create a prototype module for user secret decryption

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
   in {
 
     nixosModules.age = import ./modules/age.nix;
+    homeManagerModules.age = import ./modules/hm-age.nix;
 
     overlay = import ./overlay.nix;
 

--- a/modules/hm-age.nix
+++ b/modules/hm-age.nix
@@ -1,0 +1,115 @@
+{ config, options, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.age;
+
+  # we need at least rage 0.5.0 to support ssh keys
+  rage =
+    if lib.versionOlder pkgs.rage.version "0.5.0"
+    then pkgs.callPackage ../pkgs/rage.nix { }
+    else pkgs.rage;
+  ageBin = "${rage}/bin/rage";
+
+  identities = builtins.concatStringsSep " " (map (path: "-i ${path}") cfg.sshKeyPaths);
+  installSecret = secretType: ''
+    echo "decrypting ${secretType.file} to ${secretType.path}..."
+    TMP_FILE="${secretType.path}.tmp"
+    $DRY_RUN_CMD mkdir $VERBOSE_ARG -p $(dirname ${secretType.path})
+    (
+      umask u=r,g=,o=
+      $DRY_RUN_CMD ${ageBin} --decrypt ${identities} -o "$TMP_FILE" "${secretType.file}"
+    )
+    $DRY_RUN_CMD chmod $VERBOSE_ARG ${secretType.mode} "$TMP_FILE"
+    $DRY_RUN_CMD chown $VERBOSE_ARG ${secretType.owner}:${secretType.group} "$TMP_FILE"
+    $DRY_RUN_CMD mv $VERBOSE_ARG -f "$TMP_FILE" "${secretType.path}"
+  '';
+
+  isRootSecret = st: (st.owner == "root" || st.owner == "0") && (st.group == "root" || st.group == "0");
+  isNotRootSecret = st: !(isRootSecret st);
+
+  rootOwnedSecrets = builtins.filter isRootSecret (builtins.attrValues cfg.secrets);
+  installRootOwnedSecrets = builtins.concatStringsSep "\n" ([ "echo '[agenix] decrypting root secrets...'" ] ++ (map installSecret rootOwnedSecrets));
+
+  nonRootSecrets = builtins.filter isNotRootSecret (builtins.attrValues cfg.secrets);
+  installNonRootSecrets = builtins.concatStringsSep "\n" ([ "echo '[agenix] decrypting non-root secrets...'" ] ++ (map installSecret nonRootSecrets));
+
+  secretType = types.submodule ({ config, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        default = config._module.args.name;
+        description = ''
+          Name of the file used in /run/user/<uid>/secrets
+        '';
+      };
+      file = mkOption {
+        type = types.path;
+        description = ''
+          Age file the secret is loaded from.
+        '';
+      };
+      path = mkOption {
+        type = types.str;
+        default = "/run/user/$UID/secrets/${config.name}";
+        description = ''
+          Path where the decrypted secret is installed.
+        '';
+      };
+      mode = mkOption {
+        type = types.str;
+        default = "0400";
+        description = ''
+          Permissions mode of the in octal.
+        '';
+      };
+      owner = mkOption {
+        type = types.str;
+        default = "$UID";
+        description = ''
+          User of the file.
+        '';
+      };
+      group = mkOption {
+        type = types.str;
+        default = "$(id -g)";
+        description = ''
+          Group of the file.
+        '';
+      };
+    };
+  });
+in
+{
+  options.age = {
+    secrets = mkOption {
+      type = types.attrsOf secretType;
+      default = { };
+      description = ''
+        Attrset of secrets.
+      '';
+    };
+    sshKeyPaths = mkOption {
+      type = types.listOf types.path;
+      default = [];
+        #if config.services.openssh.enable then
+        #  map (e: e.path) (lib.filter (e: e.type == "rsa" || e.type == "ed25519") config.services.openssh.hostKeys)
+        #else [ ];
+      description = ''
+        Path to SSH keys to be used as identities in age decryption.
+      '';
+    };
+  };
+  config = mkIf (cfg.secrets != { }) (mkMerge [
+
+    {
+      assertions = [{
+        assertion = cfg.sshKeyPaths != [ ];
+        message = "age.sshKeyPaths must be set.";
+      }];
+
+      home.activation.agenix = hm.dag.entryAfter [ "writeBoundary" ] installNonRootSecrets;
+    }
+  ]);
+}

--- a/modules/hm-age.nix
+++ b/modules/hm-age.nix
@@ -84,10 +84,6 @@ in
         Attrset of secrets.
       '';
     };
-    sshAskpass = mkOption {
-      type = types.str;
-      default = "${pkgs.ssh-askpass-fullscreen}/bin/ssh-askpass-fullscreen";
-    };
     sshKeyPaths = mkOption {
       type = types.listOf types.path;
       default = [];


### PR DESCRIPTION
This is a prototype module for user decryption with home-manager.

Some stuff might not be absolutely in line with the quality standards of the project, e.g.

- directories creation might be a bit broken ;
- sshKeyPaths stuff should handled better (accept `[]` and let rage find out the proper key?)
- reuse of passphrase is not implemented (are SSH agents working? it seems like not)
- cleanup of rootSecret code? does root secrets still make sense in a user context?

cc #50 

I can confirm this code provides me with HM-integration of agenix, as seen on https://github.com/RaitoBezarius/nixos-home