### PR TITLE
Install instructions: master -> main

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then add the following to your configuration.nix in the `imports` list:
   As root run:
 
 ```ShellSession
-$ nix-channel --add https://github.com/ryantm/agenix/archive/master.tar.gz agenix
+$ nix-channel --add https://github.com/ryantm/agenix/archive/main.tar.gz agenix
 $ nix-channel --update
 ```
 


### PR DESCRIPTION
Fix installation instructions for channel installation, now that the default branch name has changed.