### PR TITLE
README: clarify that 'config' has to be prefixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ but, if you want to (change the system based on your system):
    ```
 6. NixOS rebuild or use your deployment tool like usual.
 
-   The secret will be decrypted to the value of `age.secrets.secret1.path` (`/run/agenix/secret1` by default). For per-secret options controlling ownership etc, see [modules/age.nix](modules/age.nix).
+   The secret will be decrypted to the value of `config.age.secrets.secret1.path` (`/run/agenix/secret1` by default). For per-secret options controlling ownership etc, see [modules/age.nix](modules/age.nix).
 
 ## Rekeying
 


### PR DESCRIPTION
I had a small PEBMAC ("problem exists between monitor and chair") issue before realizing that `config` needs to be prefixed to `age.secrets.<name>.path`, so to clarify I thought we might add that to the readme.