### PR TITLE
Allow customizing ageBin

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,28 @@ If your secret cannot be a symlink, you should set the `symlink` option to `fals
 
 Instead of first decrypting the secret to `/run/agenix` and then symlinking to its `path`, the secret will instead be forcibly moved to its `path`. Please note that, currently, there are no cleanup mechanisms for secrets that are not symlinked by agenix.
 
+## Use other implementations
+
+This project uses the Rust implementation of age, [rage](https://github.com/str4d/rage), by default. You can change it to use the [official implementation](https://github.com/FiloSottile/age).
+
+### Module
+
+```nix
+{
+  age.ageBin = "${pkgs.age}/bin/age";
+}
+```
+
+### CLI
+
+```nix
+{
+  environment.systemPackages = [
+    (agenix.defaultPackage.x86_64-linux.override { ageBin = "${pkgs.age}/bin/age"; })
+  ];
+}
+```
+
 ## Threat model/Warnings
 
 This project has not be audited by a security professional.

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -10,7 +10,7 @@ let
     if lib.versionOlder pkgs.rage.version "0.5.0"
     then pkgs.callPackage ../pkgs/rage.nix { }
     else pkgs.rage;
-  ageBin = "${rage}/bin/rage";
+  ageBin = config.age.ageBin;
 
   users = config.users.users;
 
@@ -96,6 +96,13 @@ let
 in
 {
   options.age = {
+    ageBin = mkOption {
+      type = types.str;
+      default = "${rage}/bin/rage";
+      description = ''
+        The age executable to use.
+      '';
+    };
     secrets = mkOption {
       type = types.attrsOf secretType;
       default = { };

--- a/pkgs/agenix.nix
+++ b/pkgs/agenix.nix
@@ -8,13 +8,14 @@
   nix,
   mktemp,
   diffutils,
+  ageBin ? "${
+    # we need at least rage 0.5.0 to support ssh keys
+    if rage.version < "0.5.0"
+    then callPackage ./rage.nix {}
+    else rage
+  }/bin/rage"
 } :
 let
-  # we need at least rage 0.5.0 to support ssh keys
-  rageToUse = if rage.version < "0.5.0"
-         then callPackage ./rage.nix {}
-         else rage;
-  ageBin = "${rageToUse}/bin/rage";
   sedBin = "${gnused}/bin/sed";
   nixInstantiate = "${nix}/bin/nix-instantiate";
   mktempBin = "${mktemp}/bin/mktemp";


### PR DESCRIPTION
### Motivation

I have an old VPS which don't have a `avx2` CPU instruction. Rage won't decrypt anything on it.

```console
[nix-shell:~]$ sudo rage -i /etc/ssh/ssh_host_ed25519_key -d test.age
Illegal instruction
```

However, the [official Go implementation](https://github.com/FiloSottile/age) works well. In this PR, I add the capability for user to customize what implementation to use.

### Usage

```nix
{
  # Module
  age.ageBin = "${pkgs.age}/bin/age";
  # CLI
  environment.systemPackages = [
    (agenix.defaultPackage.x86_64-linux.override { ageBin = "${pkgs.age}/bin/age"; })
  ];
}
```