### PR TITLE
ci: add aarch64-darwin, update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1618628710,
-        "narHash": "sha256-9xIoU+BrCpjs5nfWcd/GlU7XCVdnNKJPffoNTxgGfhs=",
-        "path": "/nix/store/z1rf17q0fxj935cmplzys4gg6nxj1as0-source",
-        "rev": "7919518f0235106d050c77837df5e338fb94de5d",
-        "type": "path"
+        "lastModified": 1641016545,
+        "narHash": "sha256-JMNwvnBzG0RjGG3eH27Y5/GlJ9ryeCdGJfqGbqxnmZY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6f05cfdb1e78d36c0337516df674560e4b51c79b",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,9 @@
 
     packages."x86_64-darwin".agenix = agenix "x86_64-darwin";
     defaultPackage."x86_64-darwin" = self.packages."x86_64-darwin".agenix;
+    
+    packages."aarch64-darwin".agenix = agenix "aarch64-darwin";
+    defaultPackage."aarch64-darwin" = self.packages."aarch64-darwin".agenix;
 
     packages."x86_64-linux".agenix = agenix "x86_64-linux";
     defaultPackage."x86_64-linux" = self.packages."x86_64-linux".agenix;


### PR DESCRIPTION
Updated nixpkgs and added default package for aarch64-darwin, similar to https://github.com/ryantm/agenix/pull/80