### PR TITLE
Add default NixOS module to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
   in {
 
     nixosModules.age = import ./modules/age.nix;
+    nixosModule = self.nixosModules.age;
 
     overlay = import ./overlay.nix;
 


### PR DESCRIPTION
This adds a “default” NixOS module in flake.nix. This makes using this in flakes a little less verbose and repetitive.

Before this change:

```nix
nixpkgs.lib.nixosSystem {
  modules = [
    ./configuration.nix
    agenix.nixosModules.age
  ];
}
```

After this change:

```nix
nixpkgs.lib.nixosSystem {
  modules = [
    ./configuration.nix
    agenix.nixosModule
  ];
}
```