### PR TITLE
Integrate with home-manager when it is used as a module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,10 @@
     agenix = system: nixpkgs.legacyPackages.${system}.callPackage ./pkgs/agenix.nix {};
   in {
 
-    nixosModules.age = import ./modules/age.nix;
+    nixosModules = {
+      age = import ./modules/age.nix;
+      hm-age = import ./modules/hm-age.nix;
+    };
     nixosModule = self.nixosModules.age;
 
     overlay = import ./overlay.nix;

--- a/modules/hm-age.nix
+++ b/modules/hm-age.nix
@@ -1,0 +1,68 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  osConfig = config;
+  hmModule = { config, ... }:
+    let
+      hmConfig = config;
+      secretType = types.submodule ({ config, ... }: {
+        options = {
+          name = mkOption {
+            type = types.str;
+            default = config._module.args.name;
+            description = ''
+              Name of the file
+            '';
+          };
+          file = mkOption {
+            type = types.path;
+            description = ''
+              Age file the secret is loaded from.
+            '';
+          };
+          path = mkOption {
+            type = types.str;
+            default =
+              "${osConfig.age.secretsDir}/hm/${hmConfig.home.username}/${config.name}";
+            description = ''
+              Path where the decrypted secret is installed.
+            '';
+          };
+          mode = mkOption {
+            type = types.str;
+            default = "0400";
+            description = ''
+              Permissions mode of the decrypted secret in a format understood by chmod.
+            '';
+          };
+          symlink = mkEnableOption "symlinking secrets to their destination"
+            // {
+              default = true;
+            };
+        };
+      });
+    in {
+      options.age = {
+        secrets = mkOption {
+          type = types.attrsOf secretType;
+          default = { };
+          description = ''
+            Attrset of secrets.
+          '';
+        };
+      };
+    };
+in {
+  home-manager.sharedModules = [ hmModule ];
+  age.secrets = mkMerge (flatten (flip mapAttrsToList config.home-manager.users
+    (username: userConfig:
+      flip mapAttrsToList userConfig.age.secrets (secret: secretConfig: {
+        "hm.${username}.${secret}" = {
+          inherit (secretConfig) file path mode symlink;
+          name = "hm/${username}/${secretConfig.name}";
+          owner = username;
+        };
+      }))));
+}


### PR DESCRIPTION
### Description
This is an alternative approach to #50. It delegates user-specific secrets configuration to the system agenix module, so it works when home-manager is used as a NixOS/nix-darwin module but does not work with a standalone home-manager setup. 

### Usage
The `hm-age` module needs to be added to the NixOS/nix-darwin modules. After that, `age.secrets` options can be used in the home-manager configuration. 