### PR TITLE
remove empty lines in recipient keys file

### DIFF
--- a/pkgs/agenix.nix
+++ b/pkgs/agenix.nix
@@ -114,7 +114,7 @@ trap "cleanup" 0 2 3 15
 
 function edit {
     FILE=$1
-    KEYS=$((${nixInstantiate} --eval -E "(let rules = import $RULES; in builtins.concatStringsSep \"\n\" rules.\"$FILE\".publicKeys)" | ${sedBin} 's/"//g' | ${sedBin} 's/\\n/\n/g') || exit 1)
+    KEYS=$((${nixInstantiate} --eval -E "(let rules = import $RULES; in builtins.concatStringsSep \"\n\" rules.\"$FILE\".publicKeys)" | ${sedBin} 's/"//g' | ${sedBin} 's/\\n/\n/g') | ${sedBin} '/^$/d' || exit 1)
 
     if [ -z "$KEYS" ]
     then


### PR DESCRIPTION
if not removed, empty lines will be added to the final encryption
command as --recipient '' which causes the command to fail with "invalid
recipient ''"

This is because my editor automatically appends a newline to every file so the files that contain my public keys have one extra empty line at the end.. Please let me know if I should just change this in my own configuration.