### PR TITLE
Update flake outputs structure in line with current specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,11 @@ The agenix CLI uses `rage` by default as its age implemenation, you
 can use the reference implementation `age` with Flakes like this:
 
 ```nix
-{pkgs,agenix,...}:{
+{pkgs, self, ...}:
+let
+  inherit (self.inputs) agenix;
+in
+{
   environment.systemPackages = [
     (agenix.defaultPackage.x86_64-linux.override { ageBin = "${pkgs.age}/bin/age"; })
   ];

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ To install the `agenix` binary:
       system = "x86_64-linux";
       modules = [
         ./configuration.nix
-        agenix.nixosModule
+        agenix.nixosModules.age
       ];
     };
   };
@@ -187,7 +187,7 @@ but, if you want to (change the system based on your system):
 
 ```nix
 {
-  environment.systemPackages = [ agenix.defaultPackage.x86_64-linux ];
+  environment.systemPackages = [ agenix.packages.x86_64-linux.default ];
 }
 ```
 
@@ -511,11 +511,12 @@ can use the reference implementation `age` with Flakes like this:
 ```nix
 {pkgs, self, ...}:
 let
-  inherit (self.inputs) agenix;
+  inherit (pkgs.stdenv.hostPlatform) system;
+  inherit (self.inputs.agenix.packages.${system}) agenix;
 in
 {
   environment.systemPackages = [
-    (agenix.defaultPackage.x86_64-linux.override { ageBin = "${pkgs.age}/bin/age"; })
+    (agenix.override { ageBin = "${pkgs.age}/bin/age"; })
   ];
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1665512413,
+        "narHash": "sha256-IeuXVWD+VkmdVdC3d2i7mdEWhNSEvc2GUdui09zAGpE=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "08ce9a42392cf8c7fdabf7c51069381ba5455dc7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1638587357,
@@ -16,8 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1665349835,
+        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,4 +1,0 @@
-final: prev:
-{
-  agenix = prev.callPackage ./pkgs/agenix.nix { };
-}


### PR DESCRIPTION
The current `flake.nix` has a lot of system-scoping boilerplate repetition which is oftentimes reduced in flakes by way of the `flake-utils` library or, lately, the `flake-parts` library. It is also certainly possible to do so using `nixpkgs.lib` but the third-party libraries can provide some additional stability if the flakes output API changes again.

A related issue is that the current flake outputs are lagging behind the current flakes specification, which results in an unintuitive usage by flake consumers, as well as a bunch of deprecation warnings.

This pull request would introduce the renaming of the following outputs as follows:

- `nixosModule` -> `nixosModules.default`
- `overlay` -> `overlays.default`
- `defaultPackage.<system>` -> `packages.<system>.default`

As a result, this will be a breaking change. But that's the nature of using an experimental feature, and the deprecation has been clear for a while.