### PR TITLE
Add generic age plugin support (including YubiKeys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,32 @@ can use the reference implementation `age` with Flakes like this:
 Support and development discussion is available here on GitHub and
 also through [Matrix](https://matrix.to/#/#agenix:nixos.org).
 
+## Plugin Support
+
+Agenix supports age plugins. If you want to use a specific plugin, add it to `age.plugins`.
+For example to enable YubiKey support, you have to enable the corresponding plugin:
+
+```nix
+{
+  age.plugins = [pkgs.age-plugin-yubikey];
+}
+```
+
+Note that this doesn't add the plugins to the agenix CLI. Here you will
+still only have access to the plugins that are installed on your system.
+
+## YubiKey Support
+
+YubiKeys are supported by using the age plugin `age-plugin-yubikey`.
+Be sure to setup your YubiKey as outlined in the official [instructions](https://github.com/str4d/age-plugin-yubikey#configuration),
+and add the plugin to your configuration:
+
+```nix
+{
+  age.plugins = [pkgs.age-plugin-yubikey];
+}
+```
+
 ## Threat model/Warnings
 
 This project has not been audited by a security professional.


### PR DESCRIPTION
This commit adds general support for age plugins by exposing a new option. This also cover's yubikey support. This also closes #102 and in my opinion supersedes #46.

#### Example

To enable YubiKey support all you need to do is to add the corresponding plugin to the plugin list:

```nix
{
  age.plugins = [pkgs.age-plugin-yubikey];
}
```

If anything else is required before this can be merged, let me know.