### PR TITLE
feature: update flake output format and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All files in the Nix store are readable by any system user, so it is not a suita
 
 Choose one of the following methods:
 
-* [niv](#install-via-niv) (Current recommendation)
+* [niv](#install-via-niv)
 * [nix-channel](#install-via-nix-channel)
 * [fetchTarball](#install-via-fetchTarball)
 * [flakes](#install-via-flakes)
@@ -134,8 +134,8 @@ Add the following to your configuration.nix:
   in [
     "${builtins.fetchTarball {
       url = "https://github.com/ryantm/agenix/archive/${commit}.tar.gz";
-      # replace this with an actual hash
-      sha256 = "0000000000000000000000000000000000000000000000000000";
+      # update hash from nix build output
+      sha256 = "";
     }}/modules/age.nix"
   ];
 }
@@ -168,7 +168,7 @@ To install the `agenix` binary:
       system = "x86_64-linux";
       modules = [
         ./configuration.nix
-        agenix.nixosModule
+        agenix.nixosModules.default
       ];
     };
   };
@@ -187,7 +187,7 @@ but, if you want to (change the system based on your system):
 
 ```nix
 {
-  environment.systemPackages = [ agenix.defaultPackage.x86_64-linux ];
+  environment.systemPackages = [ agenix.packages.x86_64-linux.default ];
 }
 ```
 
@@ -511,7 +511,7 @@ can use the reference implementation `age` with Flakes like this:
 ```nix
 {pkgs,agenix,...}:{
   environment.systemPackages = [
-    (agenix.defaultPackage.x86_64-linux.override { ageBin = "${pkgs.age}/bin/age"; })
+    (agenix.packages.x86_64-linux.default.override { ageBin = "${pkgs.age}/bin/age"; })
   ];
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665732960,
-        "narHash": "sha256-WBZ+uSHKFyjvd0w4inbm0cNExYTn8lpYFcHEes8tmec=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4428e23312933a196724da2df7ab78eb5e67a88e",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,38 +1,37 @@
 {
   description = "Secret management with age";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs }:
-  let
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
     agenix = system: nixpkgs.legacyPackages.${system}.callPackage ./pkgs/agenix.nix {};
   in {
-
     nixosModules.age = import ./modules/age.nix;
-    nixosModule = self.nixosModules.age;
+    nixosModules.default = self.nixosModules.age;
 
-    overlay = import ./overlay.nix;
+    overlays.default = import ./overlay.nix;
 
-    packages."aarch64-linux".agenix = agenix "aarch64-linux";
-    defaultPackage."aarch64-linux" = self.packages."aarch64-linux".agenix;
+    packages.aarch64-linux.agenix = agenix "aarch64-linux";
+    packages.aarch64-linux.default = self.packages.aarch64-linux.agenix;
 
-    packages."i686-linux".agenix = agenix "i686-linux";
-    defaultPackage."i686-linux" = self.packages."i686-linux".agenix;
+    packages.i686-linux.agenix = agenix "i686-linux";
+    packages.i686-linux.default = self.packages.i686-linux.agenix;
 
-    packages."x86_64-darwin".agenix = agenix "x86_64-darwin";
-    defaultPackage."x86_64-darwin" = self.packages."x86_64-darwin".agenix;
+    packages.x86_64-darwin.agenix = agenix "x86_64-darwin";
+    packages.x86_64-darwin.default = self.packages.x86_64-darwin.agenix;
 
-    packages."aarch64-darwin".agenix = agenix "aarch64-darwin";
-    defaultPackage."aarch64-darwin" = self.packages."aarch64-darwin".agenix;
+    packages.aarch64-darwin.agenix = agenix "aarch64-darwin";
+    packages.aarch64-darwin.default = self.packages.aarch64-darwin.agenix;
 
-    packages."x86_64-linux".agenix = agenix "x86_64-linux";
-    defaultPackage."x86_64-linux" = self.packages."x86_64-linux".agenix;
-    checks."x86_64-linux".integration = import ./test/integration.nix {
-      inherit nixpkgs; pkgs = nixpkgs.legacyPackages."x86_64-linux"; system = "x86_64-linux";
+    packages.x86_64-linux.agenix = agenix "x86_64-linux";
+    packages.x86_64-linux.default = self.packages.x86_64-linux.agenix;
+    checks.x86_64-linux.integration = import ./test/integration.nix {
+      inherit nixpkgs;
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      system = "x86_64-linux";
     };
-
   };
-
 }


### PR DESCRIPTION
* New flake output format, and the old one causes warnings on recent versions of nix
* Remove extraneous quotes from the flake.nix
* Now that all maintained versions of nixpkgs have the features we need, we don't need an explicit nixpkgs input
* Update docs for the new output format

closes #126