### PR TITLE
Expand tests

### DIFF
--- a/test/install_ssh_host_keys.nix
+++ b/test/install_ssh_host_keys.nix
@@ -3,13 +3,17 @@
   system.activationScripts.agenixInstall.deps = ["installSSHHostKeys"];
 
   system.activationScripts.installSSHHostKeys.text = ''
-    mkdir -p /etc/ssh
-    (umask u=rw,g=r,o=r; cp ${../example_keys/system1.pub} /etc/ssh/ssh_host_ed25519_key.pub)
+    mkdir -p /etc/ssh /home/user1/.ssh
+    (
+      umask u=rw,g=r,o=r
+      cp ${../example_keys/system1.pub} /etc/ssh/ssh_host_ed25519_key.pub
+      cp ${../example_keys/user1.pub} /home/user1/.ssh/id_ed25519.pub
+    )
     (
       umask u=rw,g=,o=
       cp ${../example_keys/system1} /etc/ssh/ssh_host_ed25519_key
+      cp ${../example_keys/user1} /home/user1/.ssh/id_ed25519
       touch /etc/ssh/ssh_host_rsa_key
     )
-
   '';
 }

--- a/test/integration.nix
+++ b/test/integration.nix
@@ -6,13 +6,12 @@
       config = {};
     },
   system ? builtins.currentSystem,
-} @ args:
-import "${nixpkgs}/nixos/tests/make-test-python.nix" ({pkgs, ...}: {
+}:
+pkgs.nixosTest {
   name = "agenix-integration";
-
   nodes.system1 = {
     config,
-    lib,
+    pkgs,
     options,
     ...
   }: {
@@ -62,5 +61,4 @@ import "${nixpkgs}/nixos/tests/make-test-python.nix" ({pkgs, ...}: {
     system1.wait_for_file("/tmp/1")
     assert "${user}" in system1.succeed("cat /tmp/1")
   '';
-})
-args
+}

--- a/test/integration.nix
+++ b/test/integration.nix
@@ -28,6 +28,10 @@ pkgs.nixosTest {
 
     age.identityPaths = options.age.identityPaths.default ++ ["/etc/ssh/this_key_wont_exist"];
 
+    environment.systemPackages = [
+      (pkgs.callPackage ../pkgs/agenix.nix {})
+    ];
+
     users = {
       mutableUsers = false;
 


### PR DESCRIPTION
This PR
- adopts the tests for linux to use the new-style tests
- adds the CLI to the integration tests
- adds an example CLI test for the `--rekey` function

Let me know what you think about this approach -- I'm kind of excited. If there are no major concerns I'll be happy to chip away at adding a few additional tests and seeing whether I can sort out the darwin tests as well.