### PR TITLE
fix: if an identity is specified, don't use the default ones

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -107,11 +107,13 @@ function edit {
     if [ -f "$FILE" ]
     then
         DECRYPT=("${DEFAULT_DECRYPT[@]}")
-        if [ -f "$HOME/.ssh/id_rsa" ]; then
-            DECRYPT+=(--identity "$HOME/.ssh/id_rsa")
-        fi
-        if [ -f "$HOME/.ssh/id_ed25519" ]; then
-            DECRYPT+=(--identity "$HOME/.ssh/id_ed25519")
+        if [[ "${DECRYPT[*]}" != *"--identity"* ]]; then
+            if [ -f "$HOME/.ssh/id_rsa" ]; then
+                DECRYPT+=(--identity "$HOME/.ssh/id_rsa")
+            fi
+            if [ -f "$HOME/.ssh/id_ed25519" ]; then
+                DECRYPT+=(--identity "$HOME/.ssh/id_ed25519")
+            fi
         fi
         if [[ "${DECRYPT[*]}" != *"--identity"* ]]; then
           echo "No identity found to decrypt $FILE. Try adding an SSH key at $HOME/.ssh/id_rsa or $HOME/.ssh/id_ed25519 or using the --identity flag to specify a file."

--- a/test/install_ssh_host_keys.nix
+++ b/test/install_ssh_host_keys.nix
@@ -1,18 +1,24 @@
 # Do not copy this! It is insecure. This is only okay because we are testing.
-{
+{config, ...}: {
   system.activationScripts.agenixInstall.deps = ["installSSHHostKeys"];
 
   system.activationScripts.installSSHHostKeys.text = ''
+    USER1_UID="${toString config.users.users.user1.uid}"
+    USERS_GID="${toString config.users.groups.users.gid}"
+
     mkdir -p /etc/ssh /home/user1/.ssh
+    chown $USER1_UID:$USERS_GID /home/user1/.ssh
     (
       umask u=rw,g=r,o=r
       cp ${../example_keys/system1.pub} /etc/ssh/ssh_host_ed25519_key.pub
       cp ${../example_keys/user1.pub} /home/user1/.ssh/id_ed25519.pub
+      chown $USER1_UID:$USERS_GID /home/user1/.ssh/id_ed25519.pub
     )
     (
       umask u=rw,g=,o=
       cp ${../example_keys/system1} /etc/ssh/ssh_host_ed25519_key
       cp ${../example_keys/user1} /home/user1/.ssh/id_ed25519
+      chown $USER1_UID:$USERS_GID /home/user1/.ssh/id_ed25519
       touch /etc/ssh/ssh_host_rsa_key
     )
   '';


### PR DESCRIPTION
fixes #151

* Adds some basic tests for editing
* Changes agenix to not add the default identity locations, if one is specified with -i