### PR TITLE
feature: pipe cleartext into agenix -e

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -23,6 +23,8 @@ function show_help () {
   echo ' '
   echo 'EDITOR environment variable of editor to use when editing FILE'
   echo ' '
+  echo 'If STDIN is not interactive, EDITOR will be set to "cp /dev/stdin"'
+  echo ' '
   echo 'RULES environment variable with path to Nix file specifying recipient public keys.'
   echo "Defaults to './secrets.nix'"
   echo ' '
@@ -123,6 +125,8 @@ function edit {
         @ageBin@ "${DECRYPT[@]}" || exit 1
         cp "$CLEARTEXT_FILE" "$CLEARTEXT_FILE.before"
     fi
+
+    [ -t 0 ] || EDITOR='cp /dev/stdin'
 
     $EDITOR "$CLEARTEXT_FILE"
 

--- a/test/install_ssh_host_keys.nix
+++ b/test/install_ssh_host_keys.nix
@@ -21,5 +21,8 @@
       chown $USER1_UID:$USERS_GID /home/user1/.ssh/id_ed25519
       touch /etc/ssh/ssh_host_rsa_key
     )
+    cp -r "${../example}" /tmp/secrets
+    chmod -R u+rw /tmp/secrets
+    chown -R $USER1_UID:$USERS_GID /tmp/secrets
   '';
 }


### PR DESCRIPTION
If STDIN is not interactive, change EDITOR to `cp /dev/stdin`.

Also updates tests somewhat.

fixes #33