### PR TITLE
Make isDarwin check more robust

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -8,7 +8,7 @@
 with lib; let
   cfg = config.age;
 
-  isDarwin = builtins.hasAttr "darwinConfig" options.environment;
+  isDarwin = lib.attrsets.hasAttrByPath ["environment" "darwinConfig"] options;
 
   # we need at least rage 0.5.0 to support ssh keys
   rage =


### PR DESCRIPTION
The provided `isDarwin` check failed on my system because `environment` attr does not exist in `options`.

I assume that this happens because my setup is done with divnix/hive (https://github.com/divnix/hive), but I am not an expert :) (I see this PR as an opportunity to learn :); so close if I naivly do something totally wrong :) ).

Nevertheless, it is probably not a bad idea to only assume the most essential attrs to be present.