### PR TITLE
add -d/--decrypt option to decrypt a file to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,8 @@ Overriding `age.secretsMountPoint` example:
 ### agenix CLI reference
 
 ```
+agenix - edit and rekey age secret files
+
 agenix -e FILE [-i PRIVATE_KEY]
 agenix -r [-i PRIVATE_KEY]
 
@@ -490,6 +492,7 @@ options:
 -h, --help                show help
 -e, --edit FILE           edits FILE using $EDITOR
 -r, --rekey               re-encrypts all secrets with specified recipients
+-d, --decrypt FILE        decrypts FILE to STDOUT
 -i, --identity            identity to use when decrypting
 -v, --verbose             verbose output
 
@@ -498,6 +501,8 @@ FILE an age-encrypted file
 PRIVATE_KEY a path to a private SSH key used to decrypt file
 
 EDITOR environment variable of editor to use when editing FILE
+
+If STDIN is not interactive, EDITOR will be set to "cp /dev/stdin"
 
 RULES environment variable with path to Nix file specifying recipient public keys.
 Defaults to './secrets.nix'

--- a/test/integration.nix
+++ b/test/integration.nix
@@ -90,6 +90,11 @@ pkgs.nixosTest {
 
     # user1 can edit a secret by piping in contents
     system1.succeed(userDo("echo 'secret1234' | agenix -e passwordfile-user1.age"))
-    assert "secret1234" in system1.succeed(userDo("EDITOR=cat agenix -e passwordfile-user1.age"))
+
+    # and get it back out via --decrypt
+    assert "secret1234" in system1.succeed(userDo("agenix -d passwordfile-user1.age"))
+
+    # finally, the plain text should not linger around anywhere in the filesystem.
+    system1.fail("grep -r secret1234 /tmp")
   '';
 }


### PR DESCRIPTION
See https://github.com/ryantm/agenix/pull/154#issuecomment-1437566317 for some discussion.

The implementation is not super pretty, but works. Feel free to pick on the style.
I also replaced one of the `EDITOR=cat` invocations in the integration test with usage of this option.

Speaking of which, that test takes forever to run for me, it seems to wait for 5 minutes for sshd to time out. Is that expected? Maybe something related to missing entropy?