### PR TITLE
fix truncated output when decrypting a large file to stdout via -d

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -196,5 +196,5 @@ function rekey {
 }
 
 [ $REKEY -eq 1 ] && rekey && exit 0
-[ $DECRYPT_ONLY -eq 1 ] && decrypt "${FILE}" "$(keys "$FILE")" && exit 0
+[ $DECRYPT_ONLY -eq 1 ] && DEFAULT_DECRYPT+=("-o" "-") && decrypt "${FILE}" "$(keys "$FILE")" && exit 0
 edit "$FILE" && cleanup && exit 0


### PR DESCRIPTION
rage intentionally truncates large output when writing to stdout: https://github.com/str4d/rage/blob/55e52c252b4036eb76582c84cbc5b9f6ef23c67f/age/src/cli_common/file_io.rs#L219
but if told to write to "-" instead, it will not truncate: https://github.com/str4d/rage/blob/55e52c252b4036eb76582c84cbc5b9f6ef23c67f/age/src/cli_common/file_io.rs#L312