### PR TITLE
Add support for age plugins

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -82,7 +82,7 @@ with lib; let
       umask u=r,g=,o=
       test -f "${secretType.file}" || echo '[agenix] WARNING: encrypted file ${secretType.file} does not exist!'
       test -d "$(dirname "$TMP_FILE")" || echo "[agenix] WARNING: $(dirname "$TMP_FILE") does not exist!"
-      LANG=${config.i18n.defaultLocale or "C"} ${ageBin} --decrypt "''${IDENTITIES[@]}" -o "$TMP_FILE" "${secretType.file}"
+      LANG=${config.i18n.defaultLocale or "C"} PATH=${lib.makeBinPath cfg.pluginPackages} ${ageBin} --decrypt "''${IDENTITIES[@]}" -o "$TMP_FILE" "${secretType.file}"
     )
     chmod ${secretType.mode} "$TMP_FILE"
     mv -f "$TMP_FILE" "$_truePath"
@@ -196,6 +196,13 @@ in {
       '';
       description = ''
         The age executable to use.
+      '';
+    };
+    pluginPackages = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      description = ''
+        List of age plugins that should be available in $PATH during the build.
       '';
     };
     secrets = mkOption {


### PR DESCRIPTION
First of all thanks for the software :)

When `nixos-rebuild`-ing my system flake with secrets encrypted to/with my Yubikey, (r)age gave the error that it was unable to find the plugin `age-plugin-yubikey` in it's $PATH even though I was able to run it myself. This is because any installed plugins would be unavailable in the build environment.

I have added an option to the agenix module to specify the age plugin packages that should be available in the build environment. This fixed the error for me and I am now able to successfully `nixos-rebuild` with secrets decrypted from my Yubikey.

I'm still finding my way with Nix so please let me know if you need any changes (or if this is totally not the right approach at all).

Thanks!