### PR TITLE
fix: always treat link destinations as files to ensure an error when the destination is a directory

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -61,7 +61,7 @@ with lib; let
 
     ${optionalString secretType.symlink ''
       # shellcheck disable=SC2193,SC2050
-      [ "${secretType.path}" != "${cfg.secretsDir}/${secretType.name}" ] && ln -sfn "${cfg.secretsDir}/${secretType.name}" "${secretType.path}"
+      [ "${secretType.path}" != "${cfg.secretsDir}/${secretType.name}" ] && ln -sfT "${cfg.secretsDir}/${secretType.name}" "${secretType.path}"
     ''}
   '';
 
@@ -76,7 +76,7 @@ with lib; let
     _agenix_generation="$(basename "$(readlink "${cfg.secretsDir}")" || echo 0)"
     (( ++_agenix_generation ))
     echo "[agenix] symlinking new secrets to ${cfg.secretsDir} (generation $_agenix_generation)..."
-    ln -sfn "${cfg.secretsMountPoint}/$_agenix_generation" "${cfg.secretsDir}"
+    ln -sfT "${cfg.secretsMountPoint}/$_agenix_generation" "${cfg.secretsDir}"
 
     (( _agenix_generation > 1 )) && {
     echo "[agenix] removing old secrets (generation $(( _agenix_generation - 1 )))..."

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -88,7 +88,7 @@ with lib; let
     mv -f "$TMP_FILE" "$_truePath"
 
     ${optionalString secretType.symlink ''
-      [ "${secretType.path}" != "${cfg.secretsDir}/${secretType.name}" ] && ln -sfn "${cfg.secretsDir}/${secretType.name}" "${secretType.path}"
+      [ "${secretType.path}" != "${cfg.secretsDir}/${secretType.name}" ] && ln -sfT "${cfg.secretsDir}/${secretType.name}" "${secretType.path}"
     ''}
   '';
 
@@ -103,7 +103,7 @@ with lib; let
     _agenix_generation="$(basename "$(readlink ${cfg.secretsDir})" || echo 0)"
     (( ++_agenix_generation ))
     echo "[agenix] symlinking new secrets to ${cfg.secretsDir} (generation $_agenix_generation)..."
-    ln -sfn "${cfg.secretsMountPoint}/$_agenix_generation" ${cfg.secretsDir}
+    ln -sfT "${cfg.secretsMountPoint}/$_agenix_generation" ${cfg.secretsDir}
 
     (( _agenix_generation > 1 )) && {
     echo "[agenix] removing old secrets (generation $(( _agenix_generation - 1 )))..."


### PR DESCRIPTION
If a secret is used in the initrd with stage1 systemd, it will be copied into the initrd on activation time, after agenix has run. If the system is then restarted, the directory /run/agenix will be created by the initrd because the file is included in the cpio archive. This will in turn cause agenix to silently create an incorrect link `/run/agenix/0 -> /run/agenix.d/0` instead of `/run/agenix -> /run/agenix.d/0` when switching to stage2.

Technically this is not a bug in agenix, since including a secret under `/run/agenix` can be considered invalid use. Yet I believe it would be good if agenix errors in such cases instead of creating a wrong link, to make users aware of the issue. Therefore I propose to replace `ln -sfn` with `ln -sfT` which will unconditionally treat the target as a file, and as such error if the target is a directory.

Another approach is to force remove any existing directories, which might also be a desirable alternative option. This would then allow using agenix secrets in the systemd stage1 initrd without taking any special care. But as unconditionally removing might be a undesirable default behavior, this could require a new option. Do you have an opinion on this matter?