### PR TITLE
fix(home): shellcheck failure for fixed secretsDir

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -48,7 +48,7 @@ with lib; let
     test "''${#IDENTITIES[@]}" -eq 0 && echo "[agenix] WARNING: no readable identities found!"
 
     mkdir -p "$(dirname "$_truePath")"
-    # shellcheck disable=SC2193
+    # shellcheck disable=SC2193,SC2050
     [ "${secretType.path}" != "${cfg.secretsDir}/${secretType.name}" ] && mkdir -p "$(dirname "${secretType.path}")"
     (
       umask u=r,g=,o=
@@ -60,7 +60,7 @@ with lib; let
     mv -f "$TMP_FILE" "$_truePath"
 
     ${optionalString secretType.symlink ''
-      # shellcheck disable=SC2193
+      # shellcheck disable=SC2193,SC2050
       [ "${secretType.path}" != "${cfg.secretsDir}/${secretType.name}" ] && ln -sfn "${cfg.secretsDir}/${secretType.name}" "${secretType.path}"
     ''}
   '';


### PR DESCRIPTION
If you set `secretsDir` in the home-manager module to a fixed path containing no env variable, the building of the mount script will fail with shellcheck warnings like these (for `/home/eisfunke/.agenix` as `secretsDir`):

```
In /nix/store/sh4igrd310v01nlfdgw9fw7qb9ck30wm-agenix-home-manager-mount-secrets/bin/agenix-home-manager-mount-secrets line 101:
[ "/home/eisfunke/.agenix/nixNetrc" != "/home/eisfunke/.agenix/nixNetrc" ] && mkdir -p "$(dirname "/home/eisfunke/.agenix/nixNetrc")"
                                    ^-- SC2050 (warning): This expression is constant. Did you forget the $ on a variable?


In /nix/store/sh4igrd310v01nlfdgw9fw7qb9ck30wm-agenix-home-manager-mount-secrets/bin/agenix-home-manager-mount-secrets line 112:
[ "/home/eisfunke/.agenix/nixNetrc" != "/home/eisfunke/.agenix/nixNetrc" ] && ln -sfn "/home/eisfunke/.agenix/nixNetrc" "/home/eisfunke/.agenix/nixNetrc"
                                    ^-- SC2050 (warning): This expression is constant. Did you forget the $ on a variable?
```

This is a problem as not having an env var in my `secretsDir` was the entire reason that I modified it at all, because not all applications accept env vars in paths (e.g. my usecase: the Nix config won't resolve the env vars `net-rc-file` which I want to set to an agenix secret).

Ignoring SC2050 in the corresponding lines in age-home.nix fixed this for me.