### PR TITLE
fix: add --strict nix-instantiate to support builtins.readFile

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -115,7 +115,7 @@ function cleanup {
 trap "cleanup" 0 2 3 15
 
 function keys {
-    (@nixInstantiate@ --json --eval -E "(let rules = import $RULES; in rules.\"$FILE\".publicKeys)" | @jqBin@ -r .[]) || exit 1
+    (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in rules.\"$FILE\".publicKeys)" | @jqBin@ -r .[]) || exit 1
 }
 
 function decrypt {


### PR DESCRIPTION
If a user has a `secrets.nix` that uses `builtins.readFile` to set the value of a key, as such:
```
let
  system = builtins.readFile ../hosts/server/ssh_host_ed25519_key.pub;

in
{
  "rootPassword.age".publicKeys = [ system ];
}
```

an error occurs:
```
❯ nix-instantiate --eval --json secrets.nix
error:
       … message for the trace

         at /home/will/Projects/nixos-config/secrets/secrets.nix:10:3:

            9| {
           10|   "rootPassword.age".publicKeys = system;
             |   ^
           11| }

       error: cannot convert a thunk to JSON

       at /home/will/Projects/nixos-config/secrets/secrets.nix:10:3:

            9| {
           10|   "rootPassword.age".publicKeys = system;
             |   ^
           11| }
```
adding `--strict` fixes this