### PR TITLE
feat: remove empty newlines from jq query

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -115,7 +115,7 @@ function cleanup {
 trap "cleanup" 0 2 3 15
 
 function keys {
-    (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in rules.\"$FILE\".publicKeys)" | @jqBin@ -r .[]) || exit 1
+    (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in rules.\"$FILE\".publicKeys)" | @jqBin@ -r 'map(rtrimstr("\n")) .[]') || exit 1
 }
 
 function decrypt {
@@ -185,7 +185,7 @@ function edit {
 }
 
 function rekey {
-    FILES=$( (@nixInstantiate@ --json --eval -E "(let rules = import $RULES; in builtins.attrNames rules)"  | @jqBin@ -r .[]) || exit 1)
+    FILES=$( (@nixInstantiate@ --json --eval -E "(let rules = import $RULES; in builtins.attrNames rules)"  | @jqBin@ -r 'map(rtrimstr("\n")) .[]') || exit 1)
 
     for FILE in $FILES
     do


### PR DESCRIPTION
When you do not have your pubkeys in your `secrets.nix` verbatim as string but read them from file like this: `desktop1 = builtins.readFile ./desktop1.pub;`, you will end up with empty newlines in the resulting list of keys, which will add `--recipient=''` arguments to your age call, failing the call.