### PR TITLE
Fix: don't try to copy non-existing files

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -155,7 +155,10 @@ function edit {
 
     decrypt "$FILE" "$KEYS" || exit 1
 
-    cp "$CLEARTEXT_FILE" "$CLEARTEXT_FILE.before"
+    if [ -f "$CLEARTEXT_FILE" ]
+    then
+      cp "$CLEARTEXT_FILE" "$CLEARTEXT_FILE.before"
+    fi
 
     [ -t 0 ] || EDITOR='cp /dev/stdin'
 


### PR DESCRIPTION
When trying to create a new file with `agenix -e` It printed a weird `cp` error, that was confusing, and that hid the actual error I faced at https://github.com/ryantm/agenix/issues/211.

Fixes #211