### PR TITLE
Update keys functions in agenix.sh

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -115,7 +115,7 @@ function cleanup {
 trap "cleanup" 0 2 3 15
 
 function keys {
-    (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in rules.\"$FILE\".publicKeys)" | @jqBin@ -r .[]) || exit 1
+    (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in rules.\"$1\".publicKeys)" | @jqBin@ -r .[]) || exit 1
 }
 
 function decrypt {


### PR DESCRIPTION
The functions was always called with `$FILE` as first argument, but inside the argument is ignored. This change doesn' have any impact, but can solve problems caused by the keys function called with an argument different from `$FILE`