### PR TITLE
age-home: Order `agenix.service` after `basic.target`

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -211,6 +211,7 @@ in {
     systemd.user.services.agenix = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
       Unit = {
         Description = "agenix activation";
+        After = "basic.target"  # “basic boot-up,” includes impermanence's bind mounts
       };
       Service = {
         Type = "oneshot";


### PR DESCRIPTION
@jankaifer Could you confirm this resolves #219 ?
