### PR TITLE
feat: switch from rage to age

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,21 +15,29 @@ jobs:
     - run: nix fmt . -- --check
     - run: nix flake check
   tests-darwin:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v24
       with:
-        extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
+        extra_nix_config: |
+          system-features = nixos-test recursive-nix benchmark big-parallel kvm
+          extra-experimental-features = recursive-nix nix-command flakes
     - run: nix build
     - run: nix build .#doc
     - run: nix fmt . -- --check
     - run: nix flake check
     - name: "Install nix-darwin module"
       run: |
-        system=$(nix build --no-link --print-out-paths .#checks.x86_64-darwin.integration)
-        ${system}/activate-user
-        sudo ${system}/activate
+        # https://github.com/ryantm/agenix/pull/230#issuecomment-1867025385
+
+        sudo mv /etc/nix/nix.conf{,.bak}
+        nix \
+          --extra-experimental-features 'nix-command flakes' \
+          build .#checks.x86_64-darwin.integration
+
+        ./result/activate-user
+        sudo ./result/activate
     - name: "Test nix-darwin module"
       run: |
         sudo /run/current-system/sw/bin/agenix-integration

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All files in the Nix store are readable by any system user, so it is not a suita
 
 ## Notices
 
-* Password-protected ssh keys: since the underlying tool age/rage do not support ssh-agent, password-protected ssh keys do not work well. For example, if you need to rekey 20 secrets you will have to enter your password 20 times.
+* Password-protected ssh keys: since age does not support ssh-agent, password-protected ssh keys do not work well. For example, if you need to rekey 20 secrets you will have to enter your password 20 times.
 
 ## Installation
 
@@ -487,7 +487,7 @@ Example of a secret with a name different from its attrpath:
 #### `age.ageBin`
 
 `age.ageBin` the string of the path to the `age` binary. Usually, you
-don't need to change this. Defaults to `rage/bin/rage`.
+don't need to change this. Defaults to `age/bin/age`.
 
 Overriding `age.ageBin` example:
 
@@ -587,13 +587,13 @@ improved upon by reading the identities from the age file.)
 
 #### Overriding age binary
 
-The agenix CLI uses `rage` by default as its age implemenation, you
-can use the reference implementation `age` with Flakes like this:
+The agenix CLI uses `age` by default as its age implemenation, you
+can use the `rage` implementation with Flakes like this:
 
 ```nix
 {pkgs,agenix,...}:{
   environment.systemPackages = [
-    (agenix.packages.x86_64-linux.default.override { ageBin = "${pkgs.age}/bin/age"; })
+    (agenix.packages.x86_64-linux.default.override { ageBin = "${pkgs.rage}/bin/rage"; })
   ];
 }
 ```

--- a/doc/notices.md
+++ b/doc/notices.md
@@ -1,3 +1,3 @@
 # Notices {#notices}
 
-* Password-protected ssh keys: since the underlying tool age/rage do not support ssh-agent, password-protected ssh keys do not work well. For example, if you need to rekey 20 secrets you will have to enter your password 20 times.
+* Password-protected ssh keys: since age does not support ssh-agent, password-protected ssh keys do not work well. For example, if you need to rekey 20 secrets you will have to enter your password 20 times.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -166,7 +166,7 @@ Example of a secret with a name different from its attrpath:
 ### `age.ageBin`
 
 `age.ageBin` the string of the path to the `age` binary. Usually, you
-don't need to change this. Defaults to `rage/bin/rage`.
+don't need to change this. Defaults to `age/bin/age`.
 
 Overriding `age.ageBin` example:
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673295039,
-        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
+        "lastModified": 1700795494,
+        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
+        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682203081,
-        "narHash": "sha256-kRL4ejWDhi0zph/FpebFYhzqlOBrk0Pl3dzGEKSAlEw=",
+        "lastModified": 1703113217,
+        "narHash": "sha256-7ulcXOk63TIT2lVDSExj7XzFx09LpdSAPtvgtM7yQPE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "32d3e39c491e2f91152c84f8ad8b003420eab0a1",
+        "rev": "3bfaacf46133c037bb356193bd2f1765d9dc82c1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677676435,
-        "narHash": "sha256-6FxdcmQr5JeZqsQvfinIMr0XcTyTuR7EXX0H3ANShpQ=",
+        "lastModified": 1703013332,
+        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a08d6979dd7c82c4cef0dcc6ac45ab16051c1169",
+        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,9 @@
             inherit system;
             modules = [
               ./test/integration_darwin.nix
-              darwin.darwinModules.simple
+
+              # Allow new-style nix commands in CI
+              {nix.extraOptions = "experimental-features = nix-command flakes";}
 
               home-manager.darwinModules.home-manager
               {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
 
     packages = eachSystem (system: {
       agenix = nixpkgs.legacyPackages.${system}.callPackage ./pkgs/agenix.nix {};
-      doc = nixpkgs.legacyPackages.${system}.callPackage ./pkgs/doc.nix {};
+      doc = nixpkgs.legacyPackages.${system}.callPackage ./pkgs/doc.nix {inherit self;};
       default = self.packages.${system}.agenix;
     });
 

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,6 @@
             inherit system;
             modules = [
               ./test/integration_darwin.nix
-              "${darwin.outPath}/pkgs/darwin-installer/installer.nix"
               home-manager.darwinModules.home-manager
               {
                 home-manager = {

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,8 @@
             inherit system;
             modules = [
               ./test/integration_darwin.nix
+              darwin.darwinModules.simple
+
               home-manager.darwinModules.home-manager
               {
                 home-manager = {

--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -155,7 +155,7 @@ with lib; let
     '';
 in {
   options.age = {
-    package = mkPackageOption pkgs "rage" {};
+    package = mkPackageOption pkgs "age" {};
 
     secrets = mkOption {
       type = types.attrsOf secretType;

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -69,6 +69,7 @@ with lib; let
     IDENTITIES=()
     for identity in ${toString cfg.identityPaths}; do
       test -r "$identity" || continue
+      test -s "$identity" || continue
       IDENTITIES+=(-i)
       IDENTITIES+=("$identity")
     done
@@ -189,9 +190,9 @@ in {
   options.age = {
     ageBin = mkOption {
       type = types.str;
-      default = "${pkgs.rage}/bin/rage";
+      default = "${pkgs.age}/bin/age";
       defaultText = literalExpression ''
-        "''${pkgs.rage}/bin/rage"
+        "''${pkgs.age}/bin/age"
       '';
       description = ''
         The age executable to use.

--- a/pkgs/agenix.nix
+++ b/pkgs/agenix.nix
@@ -1,13 +1,13 @@
 {
   lib,
   stdenv,
-  rage,
+  age,
   jq,
   nix,
   mktemp,
   diffutils,
   substituteAll,
-  ageBin ? "${rage}/bin/rage",
+  ageBin ? "${age}/bin/age",
   shellcheck,
 }:
 stdenv.mkDerivation rec {


### PR DESCRIPTION
Why
===
* Someone said age works better with password protected keys, requiring entering the password less often.
* We switched to rage from age in https://github.com/ryantm/agenix/commit/07ce686870f52a7397164b755d721bc85f110aac because it was limiting recipients to 20. This was fixed https://github.com/FiloSottile/age/issues/139

What changed
===
* Switch from rage back to age (the reference implementation) in all the spots
* Update the docs to show how to switch back to Rage