### PR TITLE
WIP: feature: Use secret to derive addtional secrets deterministcally  

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -88,9 +88,10 @@ with lib; let
         trap "rm -f $TMP_FILE_DERIVED" EXIT
         (cat $TMP_FILE && printf ${escapeShellArg secretType.derive.path}) | \
           sha256sum -z | tr -d '-' > $TMP_FILE_DERIVED
-        ${pkgs.openssl}/bin/openssl enc -aes-256-cbc -kfile "$TMP_FILE_DERIVED" -in /dev/zero -iv "" -nosalt | \
+        (${pkgs.openssl}/bin/openssl enc -aes-256-cbc -kfile "$TMP_FILE_DERIVED" -in /dev/zero -iv 00000000000000000000000000000000 -nosalt -md sha256 | \
           tr -dc ${escapeShellArg secretType.derive.filter} | \
-          head -c ${escapeShellArg secretType.derive.length} > $TMP_FILE
+          head -c ${escapeShellArg secretType.derive.length} > $TMP_FILE) 2> /dev/null
+        test -s $TMP_FILE
     ''}
     )
     chmod ${secretType.mode} "$TMP_FILE"

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -174,7 +174,7 @@ with lib; let
           default = "A-Za-z0-9_";
         };
         length = mkOption {
-          type = types.int;
+          type = types.ints.between 1 1024;
           default = 32;
         };
       };

--- a/test/integration.nix
+++ b/test/integration.nix
@@ -24,8 +24,18 @@ pkgs.nixosTest {
 
     services.openssh.enable = true;
 
-    age.secrets.passwordfile-user1 = {
-      file = ../example/passwordfile-user1.age;
+    age.secrets = rec {
+      passwordfile-user1 = {
+        file = ../example/passwordfile-user1.age;
+      };
+      passwordfile-user1-derived =
+        passwordfile-user1
+        // {
+          derive = {
+            length = 16;
+            path = "test";
+          };
+        };
     };
 
     age.identityPaths = options.age.identityPaths.default ++ ["/etc/ssh/this_key_wont_exist"];


### PR DESCRIPTION
This PR adds functionality to derive additional secrets for an existing one without the need to encrypt an additional value.

```nix
age.secrets = rec {
 regular.file = ./secret.age;
 derived = regular // {
  derive = {
   # will be concatenated with secret and hashed, the hash will then be used as seed for an RNG 
   path = "test"
   # filter to be applied to the RNG
   filter = "A-F0-9";
  };
 };
};
```

TODO:

- [ ] doc
- [ ] tests
- [x] supress warnings during activation