### PR TITLE
agenix: fix installCheckPhase with Nix 2.3

### DIFF
--- a/pkgs/agenix.nix
+++ b/pkgs/agenix.nix
@@ -30,9 +30,13 @@ in
       shellcheck ${bin}
       ${bin} -h | grep ${version}
 
-      HOME=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+      test_tmp=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+      export HOME="$test_tmp/home"
+      export NIX_STORE_DIR="$test_tmp/nix/store"
+      export NIX_STATE_DIR="$test_tmp/nix/var"
+      mkdir -p "$HOME" "$NIX_STORE_DIR" "$NIX_STATE_DIR"
       function cleanup {
-        rm -rf $HOME
+        rm -rf "$test_tmp"
       }
       trap "cleanup" 0 2 3 15
 


### PR DESCRIPTION
As opposed to e.g. Nix 2.18, Nix 2.3 doesn't try to create a fallback store in $HOME if $NIX_STORE_DIR and $NIX_STATE_DIR aren't writable.