### PR TITLE
Turn module into file path.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,13 +23,13 @@
   }: let
     eachSystem = nixpkgs.lib.genAttrs (import systems);
   in {
-    nixosModules.age = import ./modules/age.nix;
+    nixosModules.age = ./modules/age.nix;
     nixosModules.default = self.nixosModules.age;
 
-    darwinModules.age = import ./modules/age.nix;
+    darwinModules.age = ./modules/age.nix;
     darwinModules.default = self.darwinModules.age;
 
-    homeManagerModules.age = import ./modules/age-home.nix;
+    homeManagerModules.age = ./modules/age-home.nix;
     homeManagerModules.default = self.homeManagerModules.age;
 
     overlays.default = import ./overlay.nix;


### PR DESCRIPTION
If a module is an attrset deduplicating imports does not work properly and would lead to the module system complaining about redefining options. Here is an example:

error: The option `age.identityPaths' in `/nix/store/wn50ysifrfp5qj5pp3jqpyvwh8ksz36y-source/machines/foo' is already declared in `/nix/store/wn50ysifrfp5qj5pp3jqpyvwh8ksz36y-source/common/ddclient/default.nix'.

when common/ddclient/default.nix and machines/foo/default.nix is:

{ ..., agenix, ... }: {
  imports = [
    agenix.nixosModules.age
  ];
}

Turning the module into a filepath fixes the issue.