### PR TITLE
fix: update docs for 5c1198a

### DIFF
--- a/doc/overriding-age-binary.md
+++ b/doc/overriding-age-binary.md
@@ -1,12 +1,12 @@
 # Overriding age binary {#overriding-age-binary}
 
-The agenix CLI uses `rage` by default as its age implemenation, you
-can use the reference implementation `age` with Flakes like this:
+The agenix CLI uses `age` by default as its age implemenation, you
+can use the `rage` implementation with Flakes like this:
 
 ```nix
 {pkgs,agenix,...}:{
   environment.systemPackages = [
-    (agenix.packages.x86_64-linux.default.override { ageBin = "${pkgs.age}/bin/age"; })
+    (agenix.packages.x86_64-linux.default.override { ageBin = "${pkgs.rage}/bin/rage"; })
   ];
 }
 ```


### PR DESCRIPTION
I'm not sure if /how `doc/overriding-age-binary.md` is used. If it's not used maybe it should be removed, since the same info exists in `README.md`, which got me confused initially and prompted this pr.