### PR TITLE
Improve keys function for keys with extra newlines

### DIFF
--- a/pkgs/agenix.nix
+++ b/pkgs/agenix.nix
@@ -3,6 +3,7 @@
   stdenv,
   age,
   jq,
+  gnused,
   nix,
   mktemp,
   diffutils,
@@ -18,6 +19,7 @@ in
     src = substituteAll {
       inherit ageBin version;
       jqBin = "${jq}/bin/jq";
+      sedBin = "${gnused}/bin/sed";
       nixInstantiate = "${nix}/bin/nix-instantiate";
       mktempBin = "${mktemp}/bin/mktemp";
       diffBin = "${diffutils}/bin/diff";

--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -115,7 +115,7 @@ function cleanup {
 trap "cleanup" 0 2 3 15
 
 function keys {
-    (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in rules.\"$1\".publicKeys)" | @jqBin@ -r .[]) || exit 1
+    (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in rules.\"$1\".publicKeys)" | @jqBin@ -r .[] | @sedBin@ '/^$/d') || exit 1
 }
 
 function decrypt {


### PR DESCRIPTION
This PR improves keys function to make it more robust.

---

Sometimes, keys contains "\n" at the tail of themselves. In that case, `keys` function will return content like:

```
ssh-ed25519 ...
          # <- here is an extra \n
ssh-ed25519 ...
```

When other functions use the result of `keys` function, it may leads errors. Let's say [here](https://github.com/plastic-forks/agenix/blob/2c9abfec8679a0856bb3681d3c7b02b35969c1b9/pkgs/agenix.sh#L171), it will build bad arguments:

```
--recipient 'ssh-ed25519...' --recipient '' --recipient 'ssh-ed25519...'
                                         |
                                        bad
```

which will lead an error:

```
age: error: unknown recipient type: ""
```

---

This PR uses gnused to remove the empty lines in the list of keys, which make it more robust.