### PR TITLE
fix: add --strict nix-instantiate to support builtins.readFile

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -187,7 +187,7 @@ function edit {
 }
 
 function rekey {
-    FILES=$( (@nixInstantiate@ --json --eval -E "(let rules = import $RULES; in builtins.attrNames rules)"  | @jqBin@ -r .[]) || exit 1)
+    FILES=$( (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in builtins.attrNames rules)"  | @jqBin@ -r .[]) || exit 1)
 
     for FILE in $FILES
     do


### PR DESCRIPTION
follow up from https://github.com/ryantm/agenix/pull/202

looks like some changes to the rekey function missed adding the `--strict` option?