### PR TITLE
fix: allow for newlines in keys

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -171,7 +171,9 @@ function edit {
     ENCRYPT=()
     while IFS= read -r key
     do
-        ENCRYPT+=(--recipient "$key")
+        if [ -n "$key" ]; then
+            ENCRYPT+=(--recipient "$key")
+        fi
     done <<< "$KEYS"
 
     REENCRYPTED_DIR=$(@mktempBin@ -d)


### PR DESCRIPTION
Previously, empty lines in the keys would be interpreted as a recipient key, leading to the error message `age: Error: unknown recipient type: ""`. This is easy to do if you keep your ssh keys in separate files then add them to secrets.nix using `builtins.readFile`, since editors like vim will add an invisible newline to the end of every file. (unless you set noeol)

This fixes the issue by ignoring empty lines.