### PR TITLE
Add -c create or replace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ e.g. inside your `flake.nix` file:
    * from GitHub like https://github.com/ryantm.keys.
 4. Create a secret file:
    ```ShellSession
-   $ agenix -e secret1.age
+   $ agenix -c secret1.age
    ```
    It will open a temporary file in the app configured in your $EDITOR environment variable.
    When you save that file its content will be encrypted with all the public keys mentioned in the `secrets.nix` file.
@@ -548,11 +548,13 @@ Overriding `age.secretsMountPoint` example:
 ```
 agenix - edit and rekey age secret files
 
+agenix -c FILE
 agenix -e FILE [-i PRIVATE_KEY]
 agenix -r [-i PRIVATE_KEY]
 
 options:
 -h, --help                show help
+-c, --create FILE         create or replace FILE using $EDITOR
 -e, --edit FILE           edits FILE using $EDITOR
 -r, --rekey               re-encrypts all secrets with specified recipients
 -d, --decrypt FILE        decrypts FILE to STDOUT

--- a/pkgs/agenix.nix
+++ b/pkgs/agenix.nix
@@ -55,6 +55,7 @@ in
       )
 
       cd $HOME/secrets
+      echo hello | ${bin} -c secret1.age
       test $(${bin} -d secret1.age) = "hello"
     '';
 

--- a/test/integration.nix
+++ b/test/integration.nix
@@ -120,6 +120,10 @@ pkgs.nixosTest {
     # and get it back out via --decrypt
     assert "secret1234" in system1.succeed(userDo("agenix -d passwordfile-user1.age"))
 
+    # user1 can recreate the secret without decrypting it
+    system1.succeed(userDo("echo 'secret5678' | agenix -c passwordfile-user1.age"))
+    assert "secret5678" in system1.succeed(userDo("agenix -d passwordfile-user1.age"))
+
     # finally, the plain text should not linger around anywhere in the filesystem.
     system1.fail("grep -r secret1234 /tmp")
   '';


### PR DESCRIPTION
Currently agenix's CLI expects to be able to decrypt a file before operating further on it. If I don't have access to the identity file then this means either deleting the .age first or running agenix on the remote machine.

This PR helps by adding an explicit option that creates or replaces (if a file exists) a secret file without decrypting it first.

I realised partway through that this could also be accomplished by checking if stdin is a terminal but decided that a "don't decrypt" semantic option would be a better complement. So it's an alternative to #157.