### PR TITLE
fix: missing ageBin config for home-manager module

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -8,7 +8,7 @@
 with lib; let
   cfg = config.age;
 
-  ageBin = lib.getExe config.age.package;
+  ageBin = config.age.ageBin;
 
   newGeneration = ''
     _agenix_generation="$(basename "$(readlink "${cfg.secretsDir}")" || echo 0)"
@@ -156,6 +156,17 @@ with lib; let
 in {
   options.age = {
     package = mkPackageOption pkgs "age" {};
+
+    ageBin = mkOption {
+      type = types.str;
+      default = lib.getExe pkgs.age;
+      defaultText = literalExpression ''
+        "''${pkgs.age}/bin/age"
+      '';
+      description = ''
+        The age executable to use.
+      '';
+    };
 
     secrets = mkOption {
       type = types.attrsOf secretType;


### PR DESCRIPTION
I noticed that the home-manager module does not include the same configuration option for `ageBin` that is available in the NixOS module. Instead, the config option was hard-coded using `lib.getExe pkgs.age`. This change adds the `ageBin` option and defaults it to the original `lib.getExe pkgs.age`. This is useful for anyone using the home-manager module and wanting to setup age/agenix with a plugin. For example: `ageBin = "PATH=$PATH:<AGE_PLUGIN_BIN_PATH> ${pkgs.age}/bin/age"`.