### PR TITLE
feature: add an option to output secrets in armor

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -118,6 +118,10 @@ function keys {
     (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in rules.\"$1\".publicKeys)" | @jqBin@ -r .[]) || exit 1
 }
 
+function armor {
+    (@nixInstantiate@ --json --eval --strict -E "(let rules = import $RULES; in (builtins.hasAttr \"armor\" rules.\"$1\" && rules.\"$1\".armor))") || exit 1
+}
+
 function decrypt {
     FILE=$1
     KEYS=$2
@@ -148,6 +152,7 @@ function decrypt {
 function edit {
     FILE=$1
     KEYS=$(keys "$FILE") || exit 1
+    ARMOR=$(armor "$FILE") || exit 1
 
     CLEARTEXT_DIR=$(@mktempBin@ -d)
     CLEARTEXT_FILE="$CLEARTEXT_DIR/$(basename "$FILE")"
@@ -169,6 +174,9 @@ function edit {
     [ -f "$FILE" ] && [ "$EDITOR" != ":" ] && @diffBin@ -q "$CLEARTEXT_FILE.before" "$CLEARTEXT_FILE" && warn "$FILE wasn't changed, skipping re-encryption." && return
 
     ENCRYPT=()
+    if [[ "$ARMOR" == "true" ]]; then
+        ENCRYPT+=(--armor)
+    fi
     while IFS= read -r key
     do
         if [ -n "$key" ]; then


### PR DESCRIPTION
This solve #269.

Summary: Age implementations support an `--armor` flag to output encrypted secrets in a PEM format that is human readable. This is useful for storing secrets in git as it makes diffs easier to view. This PR adds the ability to configure this option within the `secrets.nix` file as such:
```
{
  "secret1.age" = {
    publicKeys = "age1s4ks3q07t7vawcj4l8uvxvuft0paqwz8wr5f7dgt3ma9ah2nucgsfke7th";
    armor = true;
  };
}
```