### PR TITLE
Remove import for NixOS/HM modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,13 +23,13 @@
   }: let
     eachSystem = nixpkgs.lib.genAttrs (import systems);
   in {
-    nixosModules.age = import ./modules/age.nix;
+    nixosModules.age = ./modules/age.nix;
     nixosModules.default = self.nixosModules.age;
 
-    darwinModules.age = import ./modules/age.nix;
+    darwinModules.age = ./modules/age.nix;
     darwinModules.default = self.darwinModules.age;
 
-    homeManagerModules.age = import ./modules/age-home.nix;
+    homeManagerModules.age = ./modules/age-home.nix;
     homeManagerModules.default = self.homeManagerModules.age;
 
     overlays.default = import ./overlay.nix;


### PR DESCRIPTION
When using `files` on a NixOS option in the `nix repl` it fails to follow the attribute of agenix module.

Discussing with @roberth has explained that this is a "common bug" on account of mis-using the `import` for modules.

From what I understand, the `import` statement brings it into the current context so you lose the attribute of where it's defined.

Here is what I currently see:
```
nix-repl> options.age.ageBin.files
[
  "/nix/store/8kpmdb63f5i9mwdyirqki7hvvglgy1va-source/machines/nyx/configuration.nix"
]

```

After this change, the value in agenix is reported instead.
```
❯ nix repl --extra-experimental-features 'flakes repl-flake' \
           --override-input agenix /home/fmzakari/code/github.com/ryantm/agenix .

nix-repl> options.age.ageBin.files
[
  "/nix/store/99gc8rhgw43k201k34pshcsygdvbhmpy-source/modules/age.nix"
]
```