### PR TITLE
modules/age-home: Make SC2043 more verbose for identityPaths

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -38,7 +38,7 @@ with lib; let
     TMP_FILE="$_truePath.tmp"
 
     IDENTITIES=()
-    # shellcheck disable=2043
+    # shellcheck disable=SC2043 # If only one path is set in identityPaths it will fail shellcheck
     for identity in ${toString cfg.identityPaths}; do
       test -r "$identity" || continue
       IDENTITIES+=(-i)


### PR DESCRIPTION
nitpick