### PR TITLE
age-home: Use curly-brackets for XDG_RUNTIME_DIR

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -146,12 +146,12 @@ with lib; let
     baseDir =
       if isDarwin
       then "$(getconf DARWIN_USER_TEMP_DIR)"
-      else "$XDG_RUNTIME_DIR";
+      else "\${XDG_RUNTIME_DIR}";
   in "${baseDir}/${dir}";
 
   userDirectoryDescription = dir:
     literalExpression ''
-      "$XDG_RUNTIME_DIR"/${dir} on linux or "$(getconf DARWIN_USER_TEMP_DIR)"/${dir} on darwin.
+      "${XDG_RUNTIME_DIR}"/${dir} on linux or "$(getconf DARWIN_USER_TEMP_DIR)"/${dir} on darwin.
     '';
 in {
   options.age = {


### PR DESCRIPTION
To avoid having to do https://github.com/colonelpanic8/dotfiles/blob/4fd99eae63ef0ea8e6f23ac5e152352cb0fc1bf0/nixos/secrets.nix#L25C9-L29C116 while using agenix in user services.

Relevant discussion in NixOS chat: https://matrix.to/#/!RRerllqmbATpmbJgCn:nixos.org/$y_A0dX6Kj0TFTCCxQIXIK9VgqwzPXjBoZLCGbzmUxBA?via=nixos.org&via=matrix.org&via=tchncs.de

Heads-up: @colonelpanic8