### PR TITLE
Add fallback behavior to editor

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -157,7 +157,17 @@ function edit {
 
     [ ! -f "$CLEARTEXT_FILE" ] || cp "$CLEARTEXT_FILE" "$CLEARTEXT_FILE.before"
 
-    [ -t 0 ] || EDITOR='cp /dev/stdin'
+    if [ ! -t 0 ]; then
+      EDITOR='cp /dev/stdin'
+    else
+      COMMON_EDITORS=("${EDITOR}" "vim" "vi" "nvim" "nano")
+      for e in "${COMMON_EDITORS[@]}"; do
+        if command -v "$e" &> /dev/null; then
+          EDITOR="$e"
+          break
+        fi
+      done
+    fi
 
     $EDITOR "$CLEARTEXT_FILE"
 


### PR DESCRIPTION
Currently if the editor is improperly set a user will run into an error and it will fail to run. Most times users have an editor on their system but could feasibly improperly configure the editor. This simply checks if a program exists including the first editor that works as the editor.