### PR TITLE
fix: fix _agenix_generation being (very shortly) empty if readlink fails

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -29,7 +29,7 @@ with lib; let
         mount -t ramfs none "${cfg.secretsMountPoint}" -o nodev,nosuid,mode=0751
     '';
   newGeneration = ''
-    _agenix_generation="$(basename "$(readlink ${cfg.secretsDir})" || echo 0)"
+    _agenix_generation="$(basename "$(readlink "${cfg.secretsDir}" || echo 0)")"
     (( ++_agenix_generation ))
     echo "[agenix] creating new generation in ${cfg.secretsMountPoint}/$_agenix_generation"
     mkdir -p "${cfg.secretsMountPoint}"


### PR DESCRIPTION
I'm currently trying to improve agenix (mostly for myself) and realized that `_agenix_generation` never gets set properly.
When `basename` wraps `readlink` in quotes, the or condition that would return `0` never gets executed because `basename ""` doesn't fail.

This isn't really a problem atm because `(( ++_agenix_generation ))` will treat empty variables as if they were 0, but might lead to some issues in the future.
I also wrapped `${cfg.secretsDir}`in quotes in case someone sets it to a path with spaces.