### PR TITLE
doc: README: Add where to get pubkeys from GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ e.g. inside your `flake.nix` file:
      ...
      ```
    * from GitHub like https://github.com/ryantm.keys.
+   * from GitLab like https://gitlab.com/ryantm.keys.
 4. Create a secret file:
    ```ShellSession
    $ agenix -e secret1.age


### PR DESCRIPTION
This is a minor addition to compliment the GitHub line for those that use GitLab as well.