### PR TITLE
fix: bad age.identityPaths default value on darwin, bump to macOS-latest in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         # Determine architecture of GitHub runner
         ARCH=x86_64
         if [ "$(arch)" = arm64 ]; then
-            ARCH=aarch64
+          ARCH=aarch64
         fi
         # https://github.com/ryantm/agenix/pull/230#issuecomment-1867025385
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     - run: nix fmt . -- --check
     - run: nix flake check
   tests-darwin:
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v30
@@ -31,12 +31,17 @@ jobs:
     - run: nix flake check
     - name: "Install nix-darwin module"
       run: |
+        # Determine architecture of GitHub runner
+        ARCH=x86_64
+        if [ "$(arch)" = arm64 ]; then
+            ARCH=aarch64
+        fi
         # https://github.com/ryantm/agenix/pull/230#issuecomment-1867025385
 
         sudo mv /etc/nix/nix.conf{,.bak}
         nix \
           --extra-experimental-features 'nix-command flakes' \
-          build .#checks.aarch64-darwin.integration
+          build .#checks."${ARCH}"-darwin.integration
 
         ./result/activate-user
         sudo ./result/activate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
     - run: nix fmt . -- --check
     - run: nix flake check
   tests-darwin:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v24
+    - uses: cachix/install-nix-action@v30
       with:
         extra_nix_config: |
           system-features = nixos-test recursive-nix benchmark big-parallel kvm
@@ -36,7 +36,7 @@ jobs:
         sudo mv /etc/nix/nix.conf{,.bak}
         nix \
           --extra-experimental-features 'nix-command flakes' \
-          build .#checks.x86_64-darwin.integration
+          build .#checks.aarch64-darwin.integration
 
         ./result/activate-user
         sudo ./result/activate

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -228,7 +228,7 @@ in {
     identityPaths = mkOption {
       type = types.listOf types.path;
       default =
-        if (config.services.openssh.enable or false)
+        if ((config.services.openssh.enable or false) == true && config.services.openssh ? hostKeys)
         then map (e: e.path) (lib.filter (e: e.type == "rsa" || e.type == "ed25519") config.services.openssh.hostKeys)
         else if isDarwin
         then [
@@ -237,7 +237,7 @@ in {
         ]
         else [];
       defaultText = literalExpression ''
-        if (config.services.openssh.enable or false)
+        if ((config.services.openssh.enable or false) == true && config.services.openssh?hostKeys)
         then map (e: e.path) (lib.filter (e: e.type == "rsa" || e.type == "ed25519") config.services.openssh.hostKeys)
         else if isDarwin
         then [

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -228,22 +228,22 @@ in {
     identityPaths = mkOption {
       type = types.listOf types.path;
       default =
-        if ((config.services.openssh.enable or false) == true && config.services.openssh ? hostKeys)
-        then map (e: e.path) (lib.filter (e: e.type == "rsa" || e.type == "ed25519") config.services.openssh.hostKeys)
-        else if isDarwin
+        if isDarwin
         then [
           "/etc/ssh/ssh_host_ed25519_key"
           "/etc/ssh/ssh_host_rsa_key"
         ]
+        else if (config.services.openssh.enable or false)
+        then map (e: e.path) (lib.filter (e: e.type == "rsa" || e.type == "ed25519") config.services.openssh.hostKeys)
         else [];
       defaultText = literalExpression ''
-        if ((config.services.openssh.enable or false) == true && config.services.openssh?hostKeys)
-        then map (e: e.path) (lib.filter (e: e.type == "rsa" || e.type == "ed25519") config.services.openssh.hostKeys)
-        else if isDarwin
+        if isDarwin
         then [
           "/etc/ssh/ssh_host_ed25519_key"
           "/etc/ssh/ssh_host_rsa_key"
         ]
+        else if (config.services.openssh.enable or false)
+        then map (e: e.path) (lib.filter (e: e.type == "rsa" || e.type == "ed25519") config.services.openssh.hostKeys)
         else [];
       '';
       description = ''


### PR DESCRIPTION
Since LnL7/nix-darwin#1172, `services.openssh.enable` is introduced for Darwin with default value being `null` instead of a boolean. `services.openssh.hostKeys` is still not available on Darwin.

The default value of `age.IdentityPaths` assumes `services.openssh.enable` being a boolean, causing evaluation failure on Darwin if not explicitly defined.

This PR attempts to:

* Fix above issue.
* Ensures `services.openssh.hostKeys` could be picked up for Darwin if it is implemented in the future.
* Bumps `macOS-12` to `macOS-15` in CI because it is deprecated by GitHub.
