### PR TITLE
fix: make `agenixChown` depend on `agenixInstall`

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -290,6 +290,7 @@ in {
         deps = [
           "users"
           "groups"
+          "agenixInstall"
         ];
       };
 


### PR DESCRIPTION
Fixes an issue where `agenixChown` can run before `agenixInstall`, leading to an activation error like this:

```
[agenix] chowning...
chown: cannot access '/run/agenix.d//hashed-password': No such file or directory
chown: cannot access '/run/agenix.d//nix-access-tokens': No such file or directory
Activation script snippet 'agenixChown' failed (1)
[agenix] creating new generation in /run/agenix.d/5
[agenix] decrypting secrets...
decrypting '/nix/store/...-hashed-password.age' to '/run/agenix.d/5/hashed-password'...
decrypting '/nix/store/...-nix-access-tokens.age' to '/run/agenix.d/5/nix-access-tokens'...
[agenix] symlinking new secrets to /run/agenix (generation 5)...
[agenix] removing old secrets (generation 4)...
---snip---
Failed to run activate script
```

After the fix, everything will always be in the proper order, and not fail:

```
[agenix] creating new generation in /run/agenix.d/6
[agenix] decrypting secrets...
decrypting '/nix/store/...-hashed-password.age' to '/run/agenix.d/6/hashed-password'...
decrypting '/nix/store/...-nix-access-tokens.age' to '/run/agenix.d/6/nix-access-tokens'...
[agenix] symlinking new secrets to /run/agenix (generation 6)...
[agenix] removing old secrets (generation 5)...
[agenix] chowning...
---snip---
```

(This matches the already existing correct behavior in Darwin, where the `chown` step always runs after the `install` step.)