### PR TITLE
Improve `age.identityPaths must be set` error

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -257,7 +257,7 @@ in {
       assertions = [
         {
           assertion = cfg.identityPaths != [];
-          message = "age.identityPaths must be set.";
+          message = "age.identityPaths must be set, for example by enabling openssh.";
         }
       ];
     }


### PR DESCRIPTION
This error can be puzzling if you're not already aware of how this works, pointing users in the direction of openssh (which I suspect is the most common way to populate `identityPaths`) while also keeping the original message seems instructive.