### PR TITLE
doc: clarify lack of support when using nondefault implementations

### DIFF
--- a/doc/overriding-age-binary.md
+++ b/doc/overriding-age-binary.md
@@ -4,9 +4,17 @@ The agenix CLI uses `age` by default as its age implemenation, you
 can use the `rage` implementation with Flakes like this:
 
 ```nix
-{pkgs,agenix,...}:{
+{
+  pkgs,
+  lib,
+  agenix,
+  ...
+}:
+{
   environment.systemPackages = [
-    (agenix.packages.x86_64-linux.default.override { ageBin = "${pkgs.rage}/bin/rage"; })
+    (agenix.packages.x86_64-linux.default.override { ageBin = lib.getExe pkgs.rage; })
   ];
 }
 ```
+
+Please note that the behavior of alternative implementations may not match that required for agenix to function, and the agenix team does not plan to provide support for bugs encountered when using agenix with nondefault implementations.


### PR DESCRIPTION
Also format codeblock RFC style, use `lib.getExe`

re: https://github.com/ryantm/agenix/pull/330
