### PR TITLE
Disable `KeepAlive.Crashed` option to prevent unnecessary restarts

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -233,10 +233,7 @@ in
       enable = true;
       config = {
         ProgramArguments = [ mountingScript ];
-        KeepAlive = {
-          Crashed = false;
-          SuccessfulExit = false;
-        };
+        KeepAlive.SuccessfulExit = false;
         RunAtLoad = true;
         ProcessType = "Background";
         StandardOutPath = "${config.home.homeDirectory}/Library/Logs/agenix/stdout";


### PR DESCRIPTION
We previously set `KeepAlive.Crashed = false`. However, this option causes the script to restart automatically after 10 seconds (the minimum restart interval enforced by launchd), even if it has already run successfully.

As a result, you may observe excessive runs:

```nix
launchctl print gui/501/org.nix-community.home.activate-agenix | grep runs
```

This behavior can also be confirmed in the logs:

```sh
sudo log show --last boot --predicate "process == 'launchd' AND composedMessage CONTAINS 'org.nix-community.home.activate-agenix'"
```

Therefore, this PR removes this option to prevent unnecessary restarts.

**Workaround**:

```nix
# WORKAROUND: Fix agenix restart loop on Darwin
# `Crashed = false` means "restart when NOT crashed" (i.e., restart on successful exit)
# This causes the agent to restart every 10 seconds after successful completion.
# See: https://github.com/ryantm/agenix/pull/352
launchd.agents.activate-agenix.config.KeepAlive.Crashed = lib.mkForce true;
```

<details>
<summary>document</summary>

```sh
> man launchd.plist | grep Crashed -B42 -A2
KeepAlive <boolean or dictionary of stuff>
This  optional  key  is used to control whether your job is to be kept continuously running or to let demand and conditions
control the invocation. The default is false and therefore only demand will start the job. The value may be set to true  to
unconditionally  keep  the  job  alive.  Alternatively,  a dictionary of conditions may be specified to selectively control
whether launchd keeps a job alive or not. If multiple keys are provided, launchd ORs them, thus providing maximum flexibil‐
ty to the job to refine the logic and stall if necessary. If launchd finds no reason to restart the job, it falls back  on
demand  based invocation.  Jobs that exit quickly and frequently when configured to be kept alive will be throttled to con‐
serve system resources. The use of this key implicitly implies RunAtLoad, causing launchd to speculatively launch the job.

      SuccessfulExit <boolean>
      If true, the job will be restarted as long as the program exits and with an exit status of zero.  If false,  the  job
      will be restarted in the inverse condition.  This key implies that "RunAtLoad" is set to true, since the job needs to
      run at least once before an exit status can be determined.

...

      Crashed <boolean>
      If  true,  the  the  job  will be restarted as long as it exited due to a signal which is typically associated with a
      crash (SIGILL, SIGSEGV, etc.). If false, the job will be restarted in the inverse condition.
```
</details>

close #308