### PR TITLE
fix: create secrets before sysusers, chown after

### DIFF
--- a/modules/age.nix
+++ b/modules/age.nix
@@ -310,6 +310,8 @@ in
           "systemd-sysusers.service"
           "agenix-install-secrets.service"
         ];
+        # We should get restarted when agenix-install-secrets is (to chown the new secrets).
+        requires = [ "agenix-install-secrets.service" ];
         unitConfig.DefaultDependencies = "no";
 
         serviceConfig = {

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -40,7 +40,7 @@ let
     _agenix_generation="$(basename "$(readlink ${cfg.secretsDir})" || echo 0)"
   '';
   newGeneration = ''
-    _agenix_generation="$(basename "$(readlink ${cfg.secretsDir})" || echo 0)"
+    ${currentGeneration}
     (( ++_agenix_generation ))
     echo "[agenix] creating new generation in ${cfg.secretsMountPoint}/$_agenix_generation"
     mkdir -p "${cfg.secretsMountPoint}"
@@ -108,7 +108,7 @@ let
   '') cfg.identityPaths;
 
   cleanupAndLink = ''
-    _agenix_generation="$(basename "$(readlink ${cfg.secretsDir})" || echo 0)"
+    ${currentGeneration}
     (( ++_agenix_generation ))
     echo "[agenix] symlinking new secrets to ${cfg.secretsDir} (generation $_agenix_generation)..."
     ln -sfT "${cfg.secretsMountPoint}/$_agenix_generation" ${cfg.secretsDir}

--- a/modules/age.nix
+++ b/modules/age.nix
@@ -305,7 +305,11 @@ in
       systemd.services.agenix-chown = mkIf sysusersEnabled {
         wantedBy = [ "sysinit.target" ];
         # Change ownership and group after users and groups are made.
-        after = [ "systemd-sysusers.service" ];
+        # (And after secrets are created, just in case systemd-sysusers.service is disabled.)
+        after = [
+          "systemd-sysusers.service"
+          "agenix-install-secrets.service"
+        ];
         unitConfig.DefaultDependencies = "no";
 
         serviceConfig = {


### PR DESCRIPTION
This fixes the issue described in #345: using an Agenix secret as `hashedPasswordFile` with userborn enabled does not work.

Tested locally.

Please let me know if you prefer a different approach for `installSecrets` causing a non-zero exit status (the added "true" is admittedly a hack but it's pretty easy to reintroduce the bug otherwise...)