### PR TITLE
Change umask settings in age-home.nix

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -53,7 +53,7 @@ let
     # shellcheck disable=SC2193,SC2050
     [ "${secretType.path}" != "${cfg.secretsDir}/${secretType.name}" ] && mkdir -p "$(dirname "${secretType.path}")"
     (
-      umask u=r,g=,o=
+      umask u=rx,g=,o=
       test -f "${secretType.file}" || echo '[agenix] WARNING: encrypted file ${secretType.file} does not exist!'
       test -d "$(dirname "$TMP_FILE")" || echo "[agenix] WARNING: $(dirname "$TMP_FILE") does not exist!"
       LANG=${


### PR DESCRIPTION
When using:

```nix
let
  rage-with-tpm =
    pkgs.runCommand "rage-with-tpm"
    {
      nativeBuildInputs = [pkgs.makeWrapper];
      propagatedBuildInputs = [pkgs.rage];
    }
    ''
      makeWrapper ${pkgs.rage}/bin/rage $out/bin/rage \
        --prefix PATH : "${pkgs.lib.makeBinPath [pkgs.age-plugin-tpm]}"
    ''
    // {meta.mainProgram = "rage";};
in {
  age = {
    identityPaths = [age_host_identity];
    ageBin = lib.getExe rage-with-tpm;
  };

  home-manager.sharedModules = [
    {
      # systemctl status --user agenix.service
      age = {
        inherit (config.age) identityPaths;
        package = rage-with-tpm;
      };
    }
  ];
  
  environment.systemPackages = with pkgs; [
    rage-with-tpm
    age-plugin-tpm
  ];
  
```

`age-plugin-tpm` is unable to see TPM in home-manager, eg. it reports error:

```log
Error: No matching keys found
```

Note that this happens only with non-root users, the nixos activation and activation of the user activation script as root works fine.
 
With the change of  `umask u` to `rx` this problem is mitigated and the activation of agenix for normal users works.

Why exactly does this not work without `x` (execute) I have no idea.