### PR TITLE
fix: use cp instead of mv to avoid cross-filesystem mv issues

### DIFF
--- a/pkgs/agenix.sh
+++ b/pkgs/agenix.sh
@@ -193,7 +193,7 @@ function edit {
 
     mkdir -p -- "$(dirname -- "$FILE")"
 
-    mv -f -- "$REENCRYPTED_FILE" "$FILE"
+    cp -- "$REENCRYPTED_FILE" "$FILE"
 }
 
 function rekey {


### PR DESCRIPTION
This fixes https://github.com/ryantm/agenix/issues/257 - this has been reported for a while, but it looks like a PR was never submitted to fix it.
Essentially, this addresses a problem with `mv` between filesystems - for example I'm running agenix in a Docker container using colima on MacOS and this results in errors like `mv: failed to preserve ownership for 'mysecrets.age': Permission denied`. Using `cp` fixes this and I think it doesn't have any negative side effects (the whole directory is removed as part of cleanup anyway).