### PR TITLE
Bump nixpkgs to 25.11 for age >=1.3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: |
           system-features = nixos-test recursive-nix benchmark big-parallel kvm
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v30
+    - uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: |
           system-features = nixos-test recursive-nix benchmark big-parallel kvm
@@ -39,14 +39,27 @@ jobs:
         # https://github.com/ryantm/agenix/pull/230#issuecomment-1867025385
 
         sudo mv /etc/nix/nix.conf{,.bak}
+
+        # nix-darwin 25.11 requires these files to be moved before activation
+        sudo mv /etc/bashrc{,.before-nix-darwin} 2>/dev/null || true
+        sudo mv /etc/zshrc{,.before-nix-darwin} 2>/dev/null || true
+
         nix \
           --extra-experimental-features 'nix-command flakes' \
           build .#checks."${ARCH}"-darwin.integration
 
-        ./result/activate-user
+        # nix-darwin 25.11: activation now runs entirely as root, no more activate-user
         sudo ./result/activate
     - name: "Test nix-darwin module"
       run: |
+        # Wait for agenix launchd daemon to decrypt secrets (runs asynchronously after activation)
+        for i in $(seq 1 30); do
+          if [ -f /run/agenix/system-secret ]; then
+            break
+          fi
+          echo "Waiting for agenix secrets to be decrypted... ($i/30)"
+          sleep 1
+        done
         sudo /run/current-system/sw/bin/agenix-integration
     - name: "Test home-manager module"
       run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v3
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v31
       - run: nix build .#doc && mkdir -p _site/ && cp -r ./result/multi/* _site/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/flake.lock
+++ b/flake.lock
@@ -3,20 +3,20 @@
     "darwin": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-darwin"
         ]
       },
       "locked": {
-        "lastModified": 1744478979,
-        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
+        "lastModified": 1767634391,
+        "narHash": "sha256-owcSz2ICqTSvhBbhPP+1eWzi88e54rRZtfCNE5E/wwg=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
+        "rev": "08585aacc3d6d6c280a02da195fdbd4b9cf083c2",
         "type": "github"
       },
       "original": {
         "owner": "lnl7",
-        "ref": "master",
+        "ref": "nix-darwin-25.11",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -28,31 +28,48 @@
         ]
       },
       "locked": {
-        "lastModified": 1745494811,
-        "narHash": "sha256-YZCh2o9Ua1n9uCvrvi5pRxtuVNml8X2a03qIFfRKpFs=",
+        "lastModified": 1767910483,
+        "narHash": "sha256-MOU5YdVu4DVwuT5ztXgQpPuRRBjSjUGIdUzOQr9iQOY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "abfad3d2958c9e6300a883bd443512c55dfeb1be",
+        "rev": "82fb7dedaad83e5e279127a38ef410bcfac6d77c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754028485,
-        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
+        "lastModified": 1768028080,
+        "narHash": "sha256-50aDK+8eLvsLK39TzQhKNq50/HcXyP4hyxOYoPoVxjo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
+        "rev": "d03088749a110d52a4739348f39a63f84bb0be14",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1767962478,
+        "narHash": "sha256-7ywwapHmJ2/dtP0j1t9fV9KQc+byL9W9X9oG3aDS4qg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "35588f29848c57ea8ac86699278d2a410dab0adb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -62,6 +79,7 @@
         "darwin": "darwin",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin": "nixpkgs-darwin",
         "systems": "systems"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,14 @@
   description = "Secret management with age";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
     darwin = {
-      url = "github:lnl7/nix-darwin/master";
-      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:lnl7/nix-darwin/nix-darwin-25.11";
+      inputs.nixpkgs.follows = "nixpkgs-darwin";
     };
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     systems.url = "github:nix-systems/default";
@@ -18,6 +19,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-darwin,
       darwin,
       home-manager,
       systems,

--- a/test/install_ssh_host_keys_darwin.nix
+++ b/test/install_ssh_host_keys_darwin.nix
@@ -1,17 +1,18 @@
 # Do not copy this! It is insecure. This is only okay because we are testing.
 {
-  system.activationScripts.extraUserActivation.text = ''
+  system.activationScripts.postActivation.text = ''
     echo "Installing system SSH host key"
-    sudo cp ${../example_keys/system1.pub} /etc/ssh/ssh_host_ed25519_key.pub
-    sudo cp ${../example_keys/system1} /etc/ssh/ssh_host_ed25519_key
-    sudo chmod 644 /etc/ssh/ssh_host_ed25519_key.pub
-    sudo chmod 600 /etc/ssh/ssh_host_ed25519_key
+    cp ${../example_keys/system1.pub} /etc/ssh/ssh_host_ed25519_key.pub
+    cp ${../example_keys/system1} /etc/ssh/ssh_host_ed25519_key
+    chmod 644 /etc/ssh/ssh_host_ed25519_key.pub
+    chmod 600 /etc/ssh/ssh_host_ed25519_key
 
     echo "Installing user SSH host key"
-    mkdir -p "$HOME/.ssh"
-    cp ${../example_keys/user1.pub} "$HOME/.ssh/id_ed25519.pub"
-    cp ${../example_keys/user1} "$HOME/.ssh/id_ed25519"
-    chmod 644 "$HOME/.ssh/id_ed25519.pub"
-    chmod 600 "$HOME/.ssh/id_ed25519"
+    USER_HOME="/Users/runner"
+    sudo -u runner mkdir -p "$USER_HOME/.ssh"
+    sudo -u runner cp ${../example_keys/user1.pub} "$USER_HOME/.ssh/id_ed25519.pub"
+    sudo -u runner cp ${../example_keys/user1} "$USER_HOME/.ssh/id_ed25519"
+    sudo -u runner chmod 644 "$USER_HOME/.ssh/id_ed25519.pub"
+    sudo -u runner chmod 600 "$USER_HOME/.ssh/id_ed25519"
   '';
 }

--- a/test/integration.nix
+++ b/test/integration.nix
@@ -7,7 +7,7 @@
   system ? builtins.currentSystem,
   home-manager ? <home-manager>,
 }:
-pkgs.nixosTest {
+pkgs.testers.nixosTest {
   name = "agenix-integration";
   nodes.system1 =
     {


### PR DESCRIPTION
age >=1.3.0 supports post quantum cryptography. This PR is done it advance of enabling that in https://github.com/ryantm/agenix/pull/366.

nixpkgs 25.11 also needs nix >=2.18, thus bumping the actions versions.

Also handling:

```
error: 'nixosTest' has been renamed to/replaced by 'testers.nixosTest'
```

and

```
error:
       nix-darwin now uses release branches that correspond to Nixpkgs releases.
       The nix-darwin and Nixpkgs branches in use must match, but you are currently
       using nix-darwin 26.05 with Nixpkgs 25.11.

On macOS, you should use either the `nixpkgs-unstable` or
       `nixpkgs-YY.MM-darwin` branches of Nixpkgs. These correspond to the
       `master` and `nix-darwin-YY.MM` branches of nix-darwin, respectively. Check
       <https://status.nixos.org/> for the currently supported Nixpkgs releases.
```

and

```
evaluation warning: user1 profile: You are using

                      Home Manager version 26.05 and
                      Nixpkgs version 25.11.

Using mismatched versions is likely to cause errors and unexpected
                    behavior. It is therefore highly recommended to use a release of Home
                    Manager that corresponds with your chosen release of Nixpkgs.
```

and

```
error:
       Failed assertions:
       - The `system.activationScripts.extraUserActivation` option has
       been removed, as all activation now takes place as `root`. Please
       restructure your custom activation scripts appropriately,
       potentially using `sudo` if you need to run commands as a user.
```

Also update darwin CI: remove deprecated activate-user and handle /etc files for nix-darwin 25.11.