### PR TITLE
Add check for non-empty identity files

### DIFF
--- a/modules/age-home.nix
+++ b/modules/age-home.nix
@@ -43,6 +43,7 @@ let
     # shellcheck disable=2043
     for identity in ${toString cfg.identityPaths}; do
       test -r "$identity" || continue
+      test -s "$identity" || continue
       IDENTITIES+=(-i)
       IDENTITIES+=("$identity")
     done


### PR DESCRIPTION
Sorry if this has been addressed already, but I couldn't find anything regarding the `no identity found` error I was getting from `age` with the home-manager activation script. I noticed that `test -s "$identity" || continue` was missing from the `installSecret` function in the home-manager module, which would fix my issue.